### PR TITLE
Money is a runtime dependency

### DIFF
--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  
+  spec.add_dependency "money", "~> 6.0"
 
-  spec.add_development_dependency "money", "~> 6.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0.0.beta1"


### PR DESCRIPTION
Money is a runtime dependency of the Gem, it is required when requiring 'monetize'. Without this change, bundler doesn't know that it also needs to install money.
