### PR TITLE
Added missing require for monetize/core_extensions

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require "money"
+require "monetize/core_extensions"
 require "monetize/version"
 
 module Monetize


### PR DESCRIPTION
**100.to_money** and **"100".to_money** should work now as specified.

The tests work because **monetize/core_extensions** is required by **spec/core_extensions_spec.rb**.

If users of the gem are supposed to require **monetize/core_extensions** themselves, then it should be documented in the README.
