### PR TITLE
Added support for arbitrary currencies - see #8

### DIFF
--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -36,6 +36,7 @@ describe Monetize do
           expect(Monetize.parse("€5.95")).to eq Money.new(595, 'EUR')
           expect(Monetize.parse(" €5.95 ")).to eq Money.new(595, 'EUR')
           expect(Monetize.parse("£9.99")).to eq Money.new(999, 'GBP')
+          expect(Monetize.parse("R9.99")).to eq Money.new(999, 'ZAR')
         end
 
         it 'should assume default currency if not a recognised symbol' do
@@ -49,6 +50,7 @@ describe Monetize do
         it "parses formatted inputs with the currency passed as a symbol but ignores the symbol" do
           expect(Monetize.parse("$5.95")).to eq Money.new(595, 'USD')
           expect(Monetize.parse("€5.95")).to eq Money.new(595, 'USD')
+          expect(Monetize.parse("R5.95")).to eq Money.new(595, 'USD')
           expect(Monetize.parse(" €5.95 ")).to eq Money.new(595, 'USD')
           expect(Monetize.parse("£9.99")).to eq Money.new(999, 'USD')
 


### PR DESCRIPTION
Made sure that explicit currency declarations work

First detected currency will no longer be necessarily overwritten

If we were to leave max = 0 and there were multiple matches, then
no matter what else was in the matches array, the 0th element would
_never_ be selected. This is because the length of any nonblank string
is greater than zero.

extracted best match finding to method

Moved find best match method

Added tests for ZAR

Also, rebased into one commit
