### PR TITLE
Fixed currencies codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-master
-------
+# Changelog
 
-- 
+## master (next release)
+- Added correct parsing of Brazilian Real $R symbol
+- Add testing task for  Brazilian Real parsing 

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -10,8 +10,8 @@ module Monetize
     "$"    => "USD",
     "€"    => "EUR",
     "£"    => "GBP",
-    "R"    => "ZAR",
-    "R\\$" => "BRL"
+    "R$"   => "BRL",
+    "R"    => "ZAR"
   }
 
   # Class methods

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -46,6 +46,10 @@ describe Monetize do
           expect(Monetize.parse("R9.99")).to eq Money.new(999, 'ZAR')
         end
 
+        it "parses formatted inputs with Brazilian real passed as a symbol" do
+          expect(Monetize.parse("R$R9.99")).to eq Money.new(999, 'BRL')
+        end
+
         it 'should assume default currency if not a recognised symbol' do
           expect(Monetize.parse("L9.99")).to eq Money.new(999, 'USD')
         end


### PR DESCRIPTION
Invalid symbol order (one contains another prevents parsing last key R$ after R)
Double encoding of R$
