### PR TITLE
Update version of money in gemspec

### DIFF
--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "money", "~> 6.3.0"
+  spec.add_dependency "money", "~> 6.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Also, could someone push a new version to rubygems? The current one is pretty out of date and specifies money `~> 6.2.1`
