### PR TITLE
Add :assume_from_symbol option to #parse

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -21,13 +21,14 @@ module Monetize
     attr_accessor :assume_from_symbol
   end
 
-  def self.parse(input, currency = Money.default_currency)
+  def self.parse(input, currency = Money.default_currency, options = {})
     input = input.to_s.strip
 
-    computed_currency = compute_currency(input)
-    if not assume_from_symbol
-      computed_currency = input[/[A-Z]{2,3}/] || currency
-    end
+    computed_currency = if options.fetch(:assume_from_symbol) { assume_from_symbol }
+                          compute_currency(input)
+                        else
+                          input[/[A-Z]{2,3}/]
+                        end
 
     currency = computed_currency || currency || Money.default_currency
     currency = Money::Currency.wrap(currency)

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -53,6 +53,10 @@ describe Monetize do
         it 'should assume default currency if not a recognised symbol' do
           expect(Monetize.parse("L9.99")).to eq Money.new(999, 'USD')
         end
+
+        it 'parses formatted inputs without currency detection when overridden' do
+          expect(Monetize.parse("£9.99", nil, assume_from_symbol: false)).to eq Money.new(999, 'USD')
+        end
       end
 
       context 'opted out' do
@@ -74,6 +78,10 @@ describe Monetize do
 
         it "ignores the British Pounds Sterling symbol" do
           expect(Monetize.parse("£9.99")).to eq Money.new(999, 'USD')
+        end
+
+        it 'parses formatted inputs with currency detection when overridden' do
+          expect(Monetize.parse("£9.99", nil, assume_from_symbol: true)).to eq Money.new(999, 'GBP')
         end
       end
 


### PR DESCRIPTION
Ok, so we're finally upgrading to Money 6 and one issue is annoying me. I really want to use the `Monetize.assume_from_symbol` option, but not everywhere (and I don't want to audit our codebase for everywhere it could possibly affect if we change it globally).

Therefore I propose making this a method-level option. If the method level option is submitted, it will override the class level option.

Current proposal:

```
Monetize.parse("£1.00", nil, assume_from_symbol: true) # => Money.new(100, 'GBP')
```

Alternative implementation (not in this PR, but easy to add):

```
Monetize.parse_with_symbol("£1.00", nil) # => Money.new(100, 'GBP')
```
