### PR TITLE
Enable #parse to detect currency with signed amounts

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -170,6 +170,6 @@ module Monetize
   end
 
   def self.currency_symbol_regex
-    /\A(?<symbol>#{regex_safe_symbols})/
+    /\A[\+|\-]?(?<symbol>#{regex_safe_symbols})/
   end
 end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -57,6 +57,27 @@ describe Monetize do
         it 'parses formatted inputs without currency detection when overridden' do
           expect(Monetize.parse("£9.99", nil, assume_from_symbol: false)).to eq Money.new(999, 'USD')
         end
+
+        it 'parses formatted inputs with minus sign and currency symbol' do
+          expect(Monetize.parse("-€9.99")).to eq Money.new(-999, 'EUR')
+          expect(Monetize.parse("-£9.99")).to eq Money.new(-999, 'GBP')
+          expect(Monetize.parse("-R$R9.99")).to eq Money.new(-999, 'BRL')
+        end
+
+        it 'parses formatted inputs with plus and GBP passed as symbol' do
+          expect(Monetize.parse("+€9.99")).to eq Money.new(999, 'EUR')
+          expect(Monetize.parse("+£9.99")).to eq Money.new(999, 'GBP')
+          expect(Monetize.parse("+R$R9.99")).to eq Money.new(999, 'BRL')
+        end
+
+        it 'parses formatted inputs with currency symbol and postfix minus sign' do
+          expect(Monetize.parse("€9.99-")).to eq Money.new(-999, 'EUR')
+        end
+
+        it 'parses formatted inputs with currency symbol and postfix plus sign' do
+          expect(Monetize.parse("€9.99+")).to eq Money.new(999, 'EUR')
+        end
+
       end
 
       context 'opted out' do


### PR DESCRIPTION
- parse can now detect the currency from strings with signs e.g:
  - -€9,99 => #<Money fractional:-999 currency:EUR>
  - €9,99- => #<Money fractional:-999 currency:EUR>
  - +£9.99 => #<Money fractional:999 currency:GBP>
  - £9.99+ => #<Money fractional:999 currency:GBP>
