### PR TITLE
Update money dependency to 6.5.0

### DIFF
--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "money", "~> 6.4.0"
+  spec.add_dependency "money", "~> 6.5.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I added `require 'rspec/autorun'` to spec/spec_helper.rb and tests seem to pass:

```
$ bundle exec ruby -I spec spec/*_spec.rb              
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
[Coveralls] Outside the Travis environment, not sending data.
...............................................................

Finished in 0.03093 seconds (files took 0.24887 seconds to load)
63 examples, 0 failures

Randomized with seed 60798
```
