### PR TITLE
Consolidate contribution instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,16 @@
 1. Fork [the repo](https://github.com/RubyMoney/monetize)
 2. Grab dependencies: `bundle install`
 3. Make sure everything is working: `bundle exec rspec spec`
-4. Make your changes
-5. Test your changes
-5. Create a Pull Request
-6. Celebrate!!!!!
+4. Create your feature branch (`git checkout -b my-new-feature`)
+5. Make your changes
+6. Test your changes
+7. Commit your changes (`git commit -am 'Add some feature'`)
+8. Push to the branch (`git push origin my-new-feature`)
+9. Create a Pull Request
+10. Celebrate!!!!!
 
 ## Notes
 
-When contributing, please make sure to update the CHANGELOG when you submit
+When contributing, please make sure to update the [CHANGELOG.md](CHANGELOG.md) when you submit
 your pull request. Upon merging of your first pull request, you will be
 given commit access to the repository.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,4 @@ Monetize.assume_from_symbol = true
 
 ## Contributing
 
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.


### PR DESCRIPTION
Instead of having two slightly different versions of contribution instructions in README and CONTRIBUTING, have one combined list in CONTRIBUTING and link to that from the README.
