### PR TITLE
Set default Rake task to be Rspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+task default: :spec
+
+RSpec::Core::RakeTask.new


### PR DESCRIPTION
The project includes a Rakefile, so I thought it would make sense to have the task default to running rspec. So one can just run `$ rake` and it will invoke the rspec runner.