### PR TITLE
Required Forwardable to resolve NameError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Master
-- ???
+- Required Forwardable on Collection to resolve NameError [\#44](https://github.com/RubyMoney/monetize/issues/44)
 
 ## 1.3.0
 - Add NilClass extension

--- a/lib/collection.rb
+++ b/lib/collection.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'monetize'
+require 'forwardable'
 
 module Monetize
   class Collection


### PR DESCRIPTION
A NameError was being raised when requiring monetize.

Specifically, it was NameError: uninitialized constant
Monetize::Collection::Forwardable

See: [NameError: uninitialized constant Monetize::Collection::Forwardable \#44](https://github.com/RubyMoney/monetize/issues/44)