### PR TITLE
Bump Money dependency version to latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@
 - Added correct parsing of Brazilian Real $R symbol
 - Add testing task for  Brazilian Real parsing 
 - Add Lira Sign (₤) as a symbol for GBP
+
+## 1.3.1
+- Updated Money version dependency to 6.6

--- a/lib/monetize/version.rb
+++ b/lib/monetize/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Monetize
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "money", "~> 6.5.0"
+  spec.add_dependency "money", "~> 6.6"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Bump Money dependency version to latest release and dial back the pessimistic version to allow minor releases.