### PR TITLE
Parsing a Money object should return it unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@
 - Reformat code to adapt to Rubocop guidelines
 - Add config setting to always enforce currency delimiters
 - Add rake console task
+- Fix issue where parsing a Money object resulted in a Money object with its currency set to `Money.default_currency`,
+  rather than the currency that it was sent in as.

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -40,6 +40,8 @@ module Monetize
   end
 
   def self.parse(input, currency = Money.default_currency, options = {})
+    return input if input.class == Money
+
     input = input.to_s.strip
 
     computed_currency = if options.fetch(:assume_from_symbol) { assume_from_symbol }

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -210,6 +210,16 @@ describe Monetize do
       Monetize.enforce_currency_delimiters = false
     end
 
+    context 'Money object attempting to be parsed' do
+      let(:money) { Money.new(595, 'GBP') }
+
+      it 'returns the original Money object' do
+        expect(Monetize.parse(money)).to eq money
+        expect(Monetize.parse(money).currency).to eq 'GBP'
+        expect(Monetize.parse(money).cents).to eq 595
+      end
+    end
+
     context 'custom currencies with 4 decimal places' do
       before :each do
         Money::Currency.register(JSON.parse(bar, symbolize_names: true))


### PR DESCRIPTION
If we attempt to parse a Money object using `Monetize.parse`, we get a Money object where its currency has been set to `Money.default_currency` instead of the currency that it was already in.

It feels like this should instead return the object we passed in, as it is technically already a Money object and so no parsing needs to be carried out.

Example (in a Rails app):

Latest version (1.4.0)
```
irb(main):001:0> money = Monetize.parse(595, 'EUR')
=> #<Money fractional:59500 currency:EUR>
irb(main):002:0> Monetize.parse(money)
=> #<Money fractional:59500 currency:USD>
```

With changes (feature/parse-money-object)
```
irb(main):002:0> money = Monetize.parse(595, 'EUR')
=> #<Money fractional:59500 currency:EUR>
irb(main):003:0> Monetize.parse(money)
=> #<Money fractional:59500 currency:EUR>
```