### PR TITLE
Fix issues with loosing precision on BigDecimal input. Fixes #62

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -40,7 +40,8 @@ module Monetize
   end
 
   def self.parse(input, currency = Money.default_currency, options = {})
-    return input if input.class == Money
+    return input if input.is_a?(Money)
+    return from_numeric(input, currency) if input.is_a?(Numeric)
 
     input = input.to_s.strip
 

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -220,6 +220,22 @@ describe Monetize do
       end
     end
 
+    context 'parsing an instance of Numeric class' do
+      let(:fixnum)      { 10 }
+      let(:float)       { 10.0 }
+      let(:big_decimal) { BigDecimal.new('10') }
+
+      [:fixnum, :float, :big_decimal].each do |type|
+        it "returns a new Money object based on the #{type} input" do
+          money = Monetize.parse(send(type), 'USD')
+
+          expect(money).to be_instance_of(Money)
+          expect(money.currency).to eq('USD')
+          expect(money.cents).to eq(10_00)
+        end
+      end
+    end
+
     context 'custom currencies with 4 decimal places' do
       before :each do
         Money::Currency.register(JSON.parse(bar, symbolize_names: true))


### PR DESCRIPTION
When passing an instance of `BigDecimal` to `Monetize.parse` it will return an incorrect output because `.to_s` without arguments returns a scientific notation:

```ruby
>> BigDecimal.new('10').to_s
=> "0.1E2"
```

`Monetize` will strip out the `E` and consider this to be 12 cents. This fix will treat `Numeric` inputs differently using already existing `.from_numeric` method.