### PR TITLE
Do not parse the ambiguous kr symbol

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -26,7 +26,6 @@ module Monetize
     'Fr'   => 'CHF',
     'zł'   => 'PLN',
     '₸'    => 'KZT',
-    'kr'   => 'SEK'
   }
 
   MULTIPLIER_SUFFIXES = {

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -132,10 +132,6 @@ describe Monetize do
           expect(Monetize.parse('₸9.99')).to eq Money.new(999, 'KZT')
         end
 
-        it 'parses formatted inputs with Swedish krona passed as a symbol' do
-          expect(Monetize.parse('kr9.99')).to eq Money.new(999, 'SEK')
-        end
-
 
         it 'should assume default currency if not a recognised symbol' do
           expect(Monetize.parse('L9.99')).to eq Money.new(999, 'USD')
@@ -162,8 +158,6 @@ describe Monetize do
           expect(Monetize.parse('-Fr9.99')).to eq Money.new(-999, 'CHF')
           expect(Monetize.parse('-zł9.99')).to eq Money.new(-999, 'PLN')
           expect(Monetize.parse('-₸9.99')).to eq Money.new(-999, 'KZT')
-          expect(Monetize.parse('-kr9.99')).to eq Money.new(-999, 'SEK')
-
         end
 
         it 'parses formatted inputs with plus and GBP passed as symbol' do
@@ -183,7 +177,6 @@ describe Monetize do
           expect(Monetize.parse('+Fr9.99')).to eq Money.new(999, 'CHF')
           expect(Monetize.parse('+zł9.99')).to eq Money.new(999, 'PLN')
           expect(Monetize.parse('+₸9.99')).to eq Money.new(999, 'KZT')
-          expect(Monetize.parse('+kr9.99')).to eq Money.new(999, 'SEK')
         end
 
         it 'parses formatted inputs with currency symbol and postfix minus sign' do
@@ -200,6 +193,13 @@ describe Monetize do
           expect(Monetize.parse('€.45B')).to eq Money.new(450_000_000_00, 'EUR')
           expect(Monetize.parse('-$2.45B')).to eq Money.new(-2_450_000_000_00, 'USD')
           expect(Monetize.parse('€1.65T')).to eq Money.new(1_650_000_000_000_00, 'EUR')
+        end
+
+        context 'negatives' do
+          it 'ignores the ambiguous kr symbol' do
+            # Could mean either of DKK, EEK, ISK, NOK, SEK
+            expect(Monetize.parse('kr9.99')).to eq Money.new(999, 'USD')
+          end
         end
       end
 


### PR DESCRIPTION
This PR rolls back https://github.com/RubyMoney/monetize/pull/70 and adds a test to not parse "kr" (that is, parse the amount into the default currency).

The `kr` as a way to indicate a currency is ambiguous since it's used for [DKK](https://en.wikipedia.org/wiki/Danish_krone) (also [Faroese króna](https://en.wikipedia.org/wiki/Faroese_kr%C3%B3na)), [EEK](https://en.wikipedia.org/wiki/Estonian_kroon) (Estonia switched to Euro), [ISK](https://en.wikipedia.org/wiki/Icelandic_kr%C3%B3na), [NOK](https://en.wikipedia.org/wiki/Norwegian_krone) and [SEK](https://en.wikipedia.org/wiki/Swedish_krona).

In Denmark ["dkr." is used including "Dkr." and "d.kr."](http://ordnet.dk/ddo/ordbog?query=dkr.) (which I find rather odd and don't see in use very often). I don't know if similarly "fkr", "ekr", "ikr", "nkr" and/or "skr" is used anywhere; but if so, it might be a way to distinguish.

Personal preference: I'd rather not have a string parsed rather than have it parsed to something "random" (whatever was added to the monetize gem first) among equal valid results. Potentially it could be parsed into an array of possible values?