### PR TITLE
Raise Monetize::Error instead of generic ArgumentError

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -2,6 +2,7 @@
 
 require 'money'
 require 'monetize/core_extensions'
+require 'monetize/errors'
 require 'monetize/version'
 require 'collection'
 
@@ -67,6 +68,8 @@ module Monetize
 
     fractional = extract_cents(input, currency)
     Money.new(fractional, currency)
+  rescue Money::Currency::UnknownCurrency => e
+    fail ParseError, e.message
   end
 
   def self.parse_collection(input, currency = Money.default_currency, options = {})
@@ -168,7 +171,7 @@ module Monetize
     when 1
       extract_major_minor_with_single_delimiter(num, currency, used_delimiters.first)
     else
-      fail ArgumentError, 'Invalid currency amount'
+      fail ParseError, 'Invalid amount'
     end
   end
 
@@ -209,7 +212,7 @@ module Monetize
 
   def self.extract_sign(input)
     result = (input =~ /^-+(.*)$/ or input =~ /^(.*)-+$/) ? [true, $1] : [false, input]
-    fail ArgumentError, 'Invalid currency amount (hyphen)' if result[1].include?('-')
+    fail ParseError, 'Invalid amount (hyphen)' if result[1].include?('-')
     result
   end
 

--- a/lib/monetize/errors.rb
+++ b/lib/monetize/errors.rb
@@ -1,0 +1,6 @@
+module Monetize
+  class Error < StandardError; end
+
+  class ParseError < Error; end
+  class ArgumentError < Error; end
+end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -151,6 +151,18 @@ describe Monetize do
       it 'should opt out by default' do
         expect(Monetize.assume_from_symbol).to be_falsy
       end
+
+      context 'ISO code' do
+        it 'parses currency given as ISO code' do
+          expect('20.00 USD'.to_money).to eq Money.new(20_00, 'USD')
+          expect('20.00 EUR'.to_money).to eq Money.new(20_00, 'EUR')
+          expect('20.00 GBP'.to_money).to eq Money.new(20_00, 'GBP')
+        end
+
+        it 'raises an error if currency code is invalid' do
+          expect { '20.00 OMG'.to_money }.to raise_error Monetize::ParseError
+        end
+      end
     end
 
     it 'parses USD-formatted inputs under $10' do
@@ -171,9 +183,9 @@ describe Monetize do
     end
 
     it 'does not return a price if there is a price range' do
-      expect { Monetize.parse('$5.95-10.95') }.to raise_error ArgumentError
-      expect { Monetize.parse('$5.95 - 10.95') }.to raise_error ArgumentError
-      expect { Monetize.parse('$5.95 - $10.95') }.to raise_error ArgumentError
+      expect { Monetize.parse('$5.95-10.95') }.to raise_error Monetize::ParseError
+      expect { Monetize.parse('$5.95 - 10.95') }.to raise_error Monetize::ParseError
+      expect { Monetize.parse('$5.95 - $10.95') }.to raise_error Monetize::ParseError
     end
 
     it 'does not return a price for completely invalid input' do
@@ -191,7 +203,7 @@ describe Monetize do
     end
 
     it 'raises ArgumentError when unable to detect polarity' do
-      expect { Monetize.parse('-$5.95-') }.to raise_error ArgumentError
+      expect { Monetize.parse('-$5.95-') }.to raise_error Monetize::ParseError
     end
 
     it 'parses correctly strings with exactly 3 decimal digits' do
@@ -440,7 +452,7 @@ describe Monetize do
     end
 
     it 'raises ArgumentError with unsupported argument' do
-      expect { Monetize.from_numeric('100') }.to raise_error(ArgumentError)
+      expect { Monetize.from_numeric('100') }.to raise_error(Monetize::ArgumentError)
     end
 
     it 'optimizes workload' do


### PR DESCRIPTION
This allows to rescue from `Monetize::Error` when parsing an input:

```ruby
begin
  '100 OMG'.to_money
rescue Monetize::Error
  # do something
end
```