### PR TITLE
Suppress errors when using parse. Introduce parse!

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ if defined?(JRUBY_VERSION)
   gem 'json'
 elsif RUBY_VERSION =~ /^1/
   gem 'json', '~> 1.8.3'
+  gem 'tins', '~> 1.6.0'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Monetize.parse("GBP 100") == Money.new(100_00, "GBP")
 "100".to_money == Money.new(100_00, "USD")
 ```
 
+`parse` will return `nil` if it is unable to parse the input. Use `parse!` instead if you want a `Monetize::Error` (or one of the subclasses) to be raised instead:
+
+```ruby
+>> Monetize.parse('OMG 100')
+=> nil
+
+>> Monetize.parse!('OMG 100')
+Monetize::ParseError: Unknown currency 'omg'
+```
+
 Optionally, enable the ability to assume the currency from a passed symbol. Otherwise, currency symbols will be ignored, and USD used as the default currency:
 
 ```ruby

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -52,6 +52,12 @@ module Monetize
   end
 
   def self.parse(input, currency = Money.default_currency, options = {})
+    parse! input, currency, options
+  rescue Error
+    nil
+  end
+
+  def self.parse!(input, currency = Money.default_currency, options = {})
     return input if input.is_a?(Money)
     return from_numeric(input, currency) if input.is_a?(Numeric)
 

--- a/lib/monetize/core_extensions/string.rb
+++ b/lib/monetize/core_extensions/string.rb
@@ -2,7 +2,7 @@
 
 class String
   def to_money(currency = nil)
-    Monetize.parse(self, currency)
+    Monetize.parse!(self, currency)
   end
 
   def to_currency

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -182,10 +182,10 @@ describe Monetize do
       expect(Monetize.parse('1,111,234,567.89')).to eq Money.new(1_111_234_567_89, 'USD')
     end
 
-    it 'does not return a price if there is a price range' do
-      expect { Monetize.parse('$5.95-10.95') }.to raise_error Monetize::ParseError
-      expect { Monetize.parse('$5.95 - 10.95') }.to raise_error Monetize::ParseError
-      expect { Monetize.parse('$5.95 - $10.95') }.to raise_error Monetize::ParseError
+    it 'returns nil if input is a price range' do
+      expect(Monetize.parse('$5.95-10.95')).to be_nil
+      expect(Monetize.parse('$5.95 - 10.95')).to be_nil
+      expect(Monetize.parse('$5.95 - $10.95')).to be_nil
     end
 
     it 'does not return a price for completely invalid input' do
@@ -202,8 +202,8 @@ describe Monetize do
       expect(Monetize.parse('$5.95-')).to eq five_ninety_five
     end
 
-    it 'raises ArgumentError when unable to detect polarity' do
-      expect { Monetize.parse('-$5.95-') }.to raise_error Monetize::ParseError
+    it 'returns nil when unable to detect polarity' do
+      expect(Monetize.parse('-$5.95-')).to be_nil
     end
 
     it 'parses correctly strings with exactly 3 decimal digits' do
@@ -293,6 +293,18 @@ describe Monetize do
         expect('€8.883.331,0034'.to_money('EU4')).to eq Money.new(8_883_331_0034, 'EU4')
         # rubocop:enable Style/NumericLiterals
       end
+    end
+  end
+
+  describe '.parse!' do
+    it 'does not return a price if there is a price range' do
+      expect { Monetize.parse!('$5.95-10.95') }.to raise_error Monetize::ParseError
+      expect { Monetize.parse!('$5.95 - 10.95') }.to raise_error Monetize::ParseError
+      expect { Monetize.parse!('$5.95 - $10.95') }.to raise_error Monetize::ParseError
+    end
+
+    it 'raises ArgumentError when unable to detect polarity' do
+      expect { Monetize.parse!('-$5.95-') }.to raise_error Monetize::ParseError
     end
   end
 


### PR DESCRIPTION
Following Rails's conventions here. Possible `Money.find` would benefit from a similar approach.

#74 