### PR TITLE
Make 'parse' always return a Money value

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Monetize.parse("GBP 100") == Money.new(100_00, "GBP")
 
 ```ruby
 >> Monetize.parse('OMG 100')
-=> Money.empty
+=> #<Money fractional:0 currency:USD>
 
 >> Monetize.parse!('OMG 100')
 Monetize::ParseError: Unknown currency 'omg'

--- a/README.md
+++ b/README.md
@@ -33,14 +33,23 @@ Monetize.parse("GBP 100") == Money.new(100_00, "GBP")
 "100".to_money == Money.new(100_00, "USD")
 ```
 
-`parse` will return `nil` if it is unable to parse the input. Use `parse!` instead if you want a `Monetize::Error` (or one of the subclasses) to be raised instead:
+`parse` will return `Money.empty` if it is unable to parse the input. Use `parse!` instead if you want a `Monetize::Error` (or one of the subclasses) to be raised instead:
 
 ```ruby
 >> Monetize.parse('OMG 100')
-=> nil
+=> Money.empty
 
 >> Monetize.parse!('OMG 100')
 Monetize::ParseError: Unknown currency 'omg'
+```
+
+The empty value can also be customized. `nil` is another common use case:
+
+```ruby
+Monetize.empty_value = nil
+
+>> Monetize.parse('OMG 100')
+=> nil
 ```
 
 Optionally, enable the ability to assume the currency from a passed symbol. Otherwise, currency symbols will be ignored, and USD used as the default currency:

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -54,7 +54,7 @@ module Monetize
   def self.parse(input, currency = Money.default_currency, options = {})
     parse! input, currency, options
   rescue Error
-    nil
+    Money.empty
   end
 
   def self.parse!(input, currency = Money.default_currency, options = {})

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -62,7 +62,7 @@ module Monetize
   def self.parse(input, currency = Money.default_currency, options = {})
     parse! input, currency, options
   rescue Error
-    empty_value
+    options.fetch(:empty_value) { empty_value }
   end
 
   def self.parse!(input, currency = Money.default_currency, options = {})

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -49,12 +49,20 @@ module Monetize
     # though, it will try to determine the correct separator by itself. Set this
     # to true to enforce the delimiters set in the currency all the time.
     attr_accessor :enforce_currency_delimiters
+
+    # Default: `Money.empty`
+    attr_writer :empty_value
+
+    def empty_value
+      return @empty_value if instance_variable_defined?('@empty_value')
+      Money.empty
+    end
   end
 
   def self.parse(input, currency = Money.default_currency, options = {})
     parse! input, currency, options
   rescue Error
-    Money.empty
+    empty_value
   end
 
   def self.parse!(input, currency = Money.default_currency, options = {})

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -183,9 +183,9 @@ describe Monetize do
     end
 
     it 'returns nil if input is a price range' do
-      expect(Monetize.parse('$5.95-10.95')).to be_nil
-      expect(Monetize.parse('$5.95 - 10.95')).to be_nil
-      expect(Monetize.parse('$5.95 - $10.95')).to be_nil
+      expect(Monetize.parse('$5.95-10.95')).to eq Money.empty
+      expect(Monetize.parse('$5.95 - 10.95')).to eq Money.empty
+      expect(Monetize.parse('$5.95 - $10.95')).to eq Money.empty
     end
 
     it 'does not return a price for completely invalid input' do
@@ -203,7 +203,7 @@ describe Monetize do
     end
 
     it 'returns nil when unable to detect polarity' do
-      expect(Monetize.parse('-$5.95-')).to be_nil
+      expect(Monetize.parse('-$5.95-')).to eq Money.empty
     end
 
     it 'parses correctly strings with exactly 3 decimal digits' do

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -294,6 +294,15 @@ describe Monetize do
         # rubocop:enable Style/NumericLiterals
       end
     end
+
+    context 'empty value configuration' do
+      before { Monetize.empty_value = nil }
+
+      it 'returns a custom empty value' do
+        expect(Monetize.parse('$5.95-10.95')).to eq nil
+        expect(Monetize.parse('123 OMG')).to eq nil
+      end
+    end
   end
 
   describe '.parse!' do

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -296,11 +296,18 @@ describe Monetize do
     end
 
     context 'empty value configuration' do
-      before { Monetize.empty_value = nil }
-
       it 'returns a custom empty value' do
-        expect(Monetize.parse('$5.95-10.95')).to eq nil
-        expect(Monetize.parse('123 OMG')).to eq nil
+        expect(Monetize.parse('$5.95-10.95', nil, empty_value: nil)).to eq nil
+        expect(Monetize.parse('123 OMG', nil, empty_value: nil)).to eq nil
+      end
+
+      context 'with global option' do
+        before { Monetize.empty_value = nil }
+
+        it 'returns a custom empty value' do
+          expect(Monetize.parse('$5.95-10.95')).to eq nil
+          expect(Monetize.parse('123 OMG')).to eq nil
+        end
       end
     end
   end


### PR DESCRIPTION
Took a look at the new `parse`/`parse!` changes. Really awesome!

I was thinking about the way that `String#to_i` always returns a number, even if it's just 0. (Even `nil#to_i` is 0.) As a developer, you never have to worry about getting anything other than an int. (You only have to worry about sanitizing/validating the original string inputs where applicable, but that's on you.)

In the case of `Monetize.parse` and `#to_money`, I realized that the same principle applies. If it returns `nil`, then we've just replaced obligatory exception-handling with obligatory nil-handling, and I'm not sure that's actually an improvement. My thought was that it is better to return `Money.empty` and be consistent with how all of the other non-numeric string inputs behave.
