### PR TITLE
Relax rspec version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ if defined?(JRUBY_VERSION)
 elsif RUBY_VERSION =~ /^1/
   gem 'json', '~> 1.8.3'
   gem 'tins', '~> 1.6.0'
+  gem 'term-ansicolor', '~> 1.3.0'
 end
 
 gemspec

--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.0.0.beta1'
+  spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
Rspec aims to adhere to semantic versioning, so any 3.x should be safe to use.