### PR TITLE
Strip currency symbol prefix when parsing input

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -120,7 +120,7 @@ module Monetize
   def self.extract_cents(input, currency = Money.default_currency)
     multiplier_exp, input = extract_multiplier(input)
 
-    num = input.gsub(/[^\d.,'-]/, '')
+    num = input.gsub(/(?:^#{currency.symbol}|[^\d.,'-]+)/, '')
 
     negative, num = extract_sign(num)
 

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -182,6 +182,12 @@ describe Monetize do
       expect(Monetize.parse('1,111,234,567.89')).to eq Money.new(1_111_234_567_89, 'USD')
     end
 
+    it 'parses DKK-formatted inputs' do
+      expect(Monetize.parse('kr.123,45', 'DKK')).to eq Money.new(123_45, 'DKK')
+      expect(Monetize.parse('kr.123.45', 'DKK')).to eq Money.new(123_45, 'DKK')
+      expect(Monetize.parse('kr.45k', 'DKK')).to eq Money.new(45_000_00, 'DKK')
+    end
+
     it 'returns nil if input is a price range' do
       expect(Monetize.parse('$5.95-10.95')).to be_nil
       expect(Monetize.parse('$5.95 - 10.95')).to be_nil


### PR DESCRIPTION
Enable parsing DKK values that are prefixed by the symbol (“kr.”). This is not the preferred formatted value for the currency, but is used by some systems (at least Facebook Marketing API).

`Monetize.parse("kr.123.45", "DKK")` should equal `Money.new("12345", "DKK")`, but before this patch it was parsed as `Money.new("12", "DKK")`.

This patch strips the symbol of a currency from the start of the string in `extract_cents`. If the symbol includes a dot ("kr."), the dot also goes away and parsing succeeds. Always ignoring the leading dot after prefix unit would break parsing "GBP.45B".
