### PR TITLE
include AUD parsing

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -16,6 +16,7 @@ module Monetize
     'R'    => 'ZAR',
     '¥'    => 'JPY',
     'C$'   => 'CAD',
+    'AU$'   => 'AUD',
     '₼'    => 'AZN',
     '元'   => 'CNY',
     'Kč'   => 'CZK',


### PR DESCRIPTION
I added a format to allow for parsing AUD.  Based on other PR of a similar nature, it looks like the tests were removed, so I went ahead and did not add one.


Is there a better way to add a custom format than a PR?

Thanks for Monetize, it is an awesome gem and I appreciate all the hard work you do!