### PR TITLE
Replace deprecated Fixnum with Integer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'coveralls', require: false
+gem 'coveralls', '~> 0.8.17', require: false
 
 # JSON gem no longer supports ruby < 2.0.0
 if defined?(JRUBY_VERSION)

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -107,7 +107,7 @@ module Monetize
 
   def self.from_numeric(value, currency = Money.default_currency)
     case value
-    when Fixnum
+    when Integer
       from_fixnum(value, currency)
     when Numeric
       value = BigDecimal.new(value.to_s)


### PR DESCRIPTION
`Fixnum` and `Bignum` are deprecated in ruby 2.4.0