### PR TITLE
Fixnum is deprecated in ruby 2.4

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -107,7 +107,7 @@ module Monetize
 
   def self.from_numeric(value, currency = Money.default_currency)
     case value
-    when Fixnum
+    when Integer
       from_fixnum(value, currency)
     when Numeric
       value = BigDecimal.new(value.to_s)


### PR DESCRIPTION
Hi,

This solves some deprecation warning for ruby 2.4.

See https://bugs.ruby-lang.org/issues/12005