### PR TITLE
Improve conversion to Money from Hash

### DIFF
--- a/lib/monetize/core_extensions/hash.rb
+++ b/lib/monetize/core_extensions/hash.rb
@@ -2,6 +2,7 @@
 
 class Hash
   def to_money(currency = nil)
-    Money.new(self[:cents], self[:currency] || currency || Money.default_currency)
+    hash_currency = self[:currency].is_a?(Hash) ? self[:currency][:iso_code] : self[:currency]
+    Money.new(self[:cents] || self[:fractional], hash_currency || currency || Money.default_currency)
   end
 end

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -182,6 +182,14 @@ describe Monetize, 'core extensions' do
         end
       end
 
+      context 'when currency argument is a hash' do
+        subject(:hash) { {cents: 100, currency: {iso_code: 'EUR'}} }
+
+        it 'converts Hash to Money using iso_code from currency hash' do
+          expect(hash.to_money).to eq(Money.new(100, 'EUR'))
+        end
+      end
+
       context 'when no currency is passed' do
         subject(:hash) { {cents: 123} }
 
@@ -189,6 +197,14 @@ describe Monetize, 'core extensions' do
 
         it 'converts Hash to Money using default value' do
           expect(hash.to_money('USD')).to eq(Money.new(123, 'USD'))
+        end
+      end
+
+      context "when key name is 'fractional'" do
+        subject(:hash) { {fractional: 100} }
+
+        it 'converts Hash to Money, interpreting fractional as cents' do
+          expect(hash.to_money).to eq(Money.new(100, 'USD'))
         end
       end
     end


### PR DESCRIPTION
* Add conversion to Money from Hash when hash key names are the same as Money's instance variable names

Related to [money-rails](https://github.com/RubyMoney/money-rails). `as_json` method creates a hash with keys "fractional", "currency" & "bank" - identical names to Money instance variable names, also passes currency as a hash, consisting of Money::Currency instance variables. Because conversion from Hash expected "cents" key and "currency" as an ISO string, `100.to_money.as_json.to_money` failed.

I think this conversion functionality should be implemented here and not in money-rails because it's fairly common practice to use object's instance variable names when converting to Hash as I know.