### PR TITLE
Use Money#from_amount when monetizing from BigDecimal

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -101,10 +101,7 @@ module Monetize
   end
 
   def self.from_bigdecimal(value, currency = Money.default_currency)
-    currency = Money::Currency.wrap(currency)
-    value *= currency.subunit_to_unit
-    value = value.round unless Money.infinite_precision
-    Money.new(value, currency)
+    Money.from_amount(value, currency)
   end
 
   def self.from_numeric(value, currency = Money.default_currency)

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -430,6 +430,12 @@ describe Monetize do
       expect(Monetize.from_bigdecimal(BigDecimal.new('1'), 'JPY')).to eq Money.new(1, 'JPY')
     end
 
+    it 'respects rounding mode when rounding amount to the nearest cent' do
+      amount = BigDecimal.new('1.005')
+
+      expect(Monetize.from_bigdecimal(amount, 'USD')).to eq Money.from_amount(amount, 'USD')
+    end
+
     it 'accepts a currency options' do
       m = Monetize.from_bigdecimal(BigDecimal.new('1'))
       expect(m.currency).to eq Money.default_currency


### PR DESCRIPTION
This fixes an issue (https://github.com/RubyMoney/money/issues/715) caused by the wrong rounding mode used. Also all the handling of `BigDecimal` will happen in Money for a better consistency.