### PR TITLE
Sort entries in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.7.0
+- Add South Korean Won currency
 - Money version updated to 6.9
 - Coveralls version update to 0.8.20
 - Add South Korean Won currency
@@ -11,6 +12,8 @@
 - Money version updated to 6.8
 
 ## 1.5.0
+- Fix issue where parsing a Money object resulted in a Money object with its currency set to `Money.default_currency`,
+  rather than the currency that it was sent in as.
 - Add extra currencies:
   - Azerbaijani manat
   - Chinese yuan
@@ -34,24 +37,19 @@
 - Strip currency symbol prefix when parsing input
 
 ## 1.4.0
+- Fixed support for <code>Money.infinite_precision = true</code> in .to_money
+- Add Rubocop config to project
+- Reformat code to adapt to Rubocop guidelines
+- Add config setting to always enforce currency delimiters
+- Add rake console task
 - Required Forwardable on Collection to resolve NameError [\#44](https://github.com/RubyMoney/monetize/issues/44)
 - Add capability to parse currency amounts given with suffixes (K, M, B, and T)
+
+## 1.3.1
+- Updated Money version dependency to 6.6
 
 ## 1.3.0
 - Add NilClass extension
 - Added correct parsing of Brazilian Real $R symbol
 - Add testing task for  Brazilian Real parsing
 - Add Lira Sign (₤) as a symbol for GBP
-
-## 1.3.1
-- Updated Money version dependency to 6.6
-
-## master
-- Fixed support for <code>Money.infinite_precision = true</code> in .to_money
-- Add Rubocop config to project
-- Reformat code to adapt to Rubocop guidelines
-- Add config setting to always enforce currency delimiters
-- Add rake console task
-- Fix issue where parsing a Money object resulted in a Money object with its currency set to `Money.default_currency`,
-  rather than the currency that it was sent in as.
-- Add South Korean Won currency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,27 @@
 - Updated Money version dependency to 6.6
 
 ## 1.3.0
+- Add Lira Sign (₤) as a symbol for GBP
+
+## 1.2.0
+- Add support for parsing Yen symbol
+- Add `Monetize.parse_collection` and `Monetize::Collection` class for parsing multiple values
+- Add parsing of C$ for Canadian Dollar
 - Add NilClass extension
+- Add Hash extension
+
+## 1.1.0
+- Add :assume_from_symbol option to #parse
+- Enable #parse to detect currency with signed amounts
+- Updated Money version dependency to 6.5.0
+
+## 1.0.0
+- Updated Money version dependency to 6.4.0
+
+## 0.4.1
+- Updated Money version dependency to 6.2.1
+
+## 0.4.0
 - Added correct parsing of Brazilian Real $R symbol
 - Add testing task for  Brazilian Real parsing
-- Add Lira Sign (₤) as a symbol for GBP
+- Updated Money version dependency to 6.2.0


### PR DESCRIPTION
Most recent version first.

To help verify the changes, here's the story:

1. [v1.3.0](https://github.com/RubyMoney/monetize/commit/7ccc049a56a565d6de1bcb845db8dd9b562bb0ed) is out
2. 8617e1d3 added section `## 1.3.1` below `## 1.3.0` instead of above
3. [v1.3.1](https://github.com/RubyMoney/monetize/commit/ebccf58b7bff9ac40ccd9eb43ebc6b18709b8c49) is released
4. bbdac0a3 added section `## master` to the bottom instead of using section `## Master` which is present at the top
5. 15562ac5, c902a8e8, 958de42c added entries to the bottom `## master` section
6. [v1.4.0](https://github.com/RubyMoney/monetize/commit/64e451cfaf19d852171aba822f01d2230eae54d8) is released (64e451cf), but it uses the top `## Master` section and ignores the bottom `## master`
7. 4de6016b adds an entry to the bottom `## master` section
8. [v1.5.0](https://github.com/RubyMoney/monetize/commit/4aa7caf910f2420187316a68eec937583adb94d2) is released
9. [v1.6.0](https://github.com/RubyMoney/monetize/commit/7dda95107a065918b90b4873c93fbc406308c2a0) is released
10. e24acba8 adds an entry to the bottom `## master` section
11. [v1.7.0](https://github.com/RubyMoney/monetize/commit/ec735fc96fcc79c8418545f65c3a6f0587bb2ec5) is released