### PR TITLE
Fix typos and remove double entry from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,18 @@
   - Chinese yuan
   - Czech koruna
   - Hungarian forint
-  - Indinan rupee
+  - Indian rupee
   - Russian ruble
   - Turkish Lira
   - Ukrainian Hryvnia
   - Swiss Frank
   - Polish Zloty
   - Kazakhstani Tenge
-- Parsing a Money object returns it unchanged
-- Fix issue with loosing precision on BigDecimal input
+- Fix issue with losing precision on BigDecimal input
 - Add Swedish krona
-- Exclud ambiguous kr symbol from parsing
+- Exclude ambiguous kr symbol from parsing
 - Fix JPY parsing
-- Sublcass all errors to Monetize::Error
+- Subclass all errors to Monetize::Error
 - Fix ruby 1.9.3 compatibility
 - Suppress errors when using parse. Use `parse!` instead
 - Strip currency symbol prefix when parsing input


### PR DESCRIPTION
Removed entry is also present earlier as:

> Fix issue where parsing a Money object resulted in a Money object
> with its currency set to `Money.default_currency`, rather than
> the currency that it was sent in as.

Both entries refer to the fix in 4de6016b. The longer version was introduced back then; the shorter one later, in 4aa7caf9 (v1.5.0 release). I kept the longer version because it describes the issue too. If you prefer the other one I can change this.