### PR TITLE
Limit rake to version 10.2 and i18n to 0.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,14 @@ source 'https://rubygems.org'
 
 gem 'coveralls', '>= 0.8.20', require: false
 
-# JSON gem no longer supports ruby < 2.0.0
+# JSON and I18n gem no longer supports ruby < 2.0.0
 if defined?(JRUBY_VERSION)
   gem 'json'
 elsif RUBY_VERSION =~ /^1/
   gem 'json', '~> 1.8.3'
   gem 'tins', '~> 1.6.0'
   gem 'term-ansicolor', '~> 1.3.0'
+  gem 'i18n', '~> 0.9'
 end
 
 gemspec

--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'money', '~> 6.12'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 10.2'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
Upper versions are no longer compatible with ruby 1.9

See https://github.com/ruby/rake/blob/master/History.rdoc#1020--2014-03-24