### PR TITLE
Respect Money.rounding_mode

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -66,6 +66,8 @@ module Monetize
     end
 
     def extract_cents(input, currency = Money.default_currency)
+      warn '[DEPRECATION] Monetize.extract_cents is deprecated. Use Monetize.parse().cents'
+
       Monetize::Parser.new(input).parse_cents(currency)
     end
   end

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -31,9 +31,9 @@ module Monetize
       return from_numeric(input, currency) if input.is_a?(Numeric)
 
       parser = Monetize::Parser.new(input, currency, options)
-      currency_from_input = Money::Currency.wrap(parser.parse_currency)
+      amount, currency = parser.parse
 
-      Money.new(parser.parse_cents(currency_from_input), currency_from_input)
+      Money.from_amount(amount, currency)
     rescue Money::Currency::UnknownCurrency => e
       fail ParseError, e.message
     end
@@ -68,7 +68,8 @@ module Monetize
     def extract_cents(input, currency = Money.default_currency)
       warn '[DEPRECATION] Monetize.extract_cents is deprecated. Use Monetize.parse().cents'
 
-      Monetize::Parser.new(input).parse_cents(currency)
+      money = parse(input, currency)
+      money.cents if money
     end
   end
 end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -520,6 +520,20 @@ describe Monetize do
   end
 
   describe '.extract_cents' do
+    it 'is deprecated' do
+      allow(Monetize).to receive(:warn)
+
+      Monetize.extract_cents('100')
+
+      expect(Monetize)
+        .to have_received(:warn)
+        .with('[DEPRECATION] Monetize.extract_cents is deprecated. Use Monetize.parse().cents')
+    end
+
+    it 'extracts cents from a given string' do
+      expect(Monetize.extract_cents('10.99')).to eq(1099)
+    end
+
     it "correctly treats pipe marks '|' in input (regression test)" do
       expect(Monetize.extract_cents('100|0')).to eq Monetize.extract_cents('100!0')
     end


### PR DESCRIPTION
For a while Monetize had its own custom logic for rounding parsed amounts. The of course completely ignores the `Money.rounding_mode` always assuming one rounding mode — `ROUND_HALF_UP`.

This PR clean some of that logic up and returns amount in units letting `Money` to convert it to subunits.

A potential breaking change here is that a correct, but different rounding mode will be used. Will add a post-install message to double check `Money.rounding_mode` is set to the desired value.