### PR TITLE
Do not parse symbols that are surrounded by characters

### DIFF
--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -82,8 +82,8 @@ module Monetize
     end
 
     def compute_currency
-      matches = input.match(currency_symbol_regex)
-      CURRENCY_SYMBOLS[matches[:symbol]] if matches
+      match = input.match(currency_symbol_regex)
+      CURRENCY_SYMBOLS[match.to_s] if match
     end
 
     def extract_major_minor(num, currency)
@@ -153,7 +153,7 @@ module Monetize
     end
 
     def currency_symbol_regex
-      /(?<symbol>#{regex_safe_symbols})/
+      /(?<![A-Z])(#{regex_safe_symbols})(?![A-Z])/i
     end
   end
 end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -118,6 +118,11 @@ describe Monetize do
           expect(Monetize.parse('L9.99')).to eq Money.new(999, 'USD')
         end
 
+        it 'ignores ZAR symbols that is part of a text' do
+          expect(Monetize.parse('EUR 9.99')).to eq Money.new(999, 'EUR')
+          expect(Monetize.parse('9.99 EUR')).to eq Money.new(999, 'EUR')
+        end
+
         context 'negatives' do
           it 'ignores the ambiguous kr symbol' do
             # Could mean either of DKK, EEK, ISK, NOK, SEK


### PR DESCRIPTION
Stop confusing letter "R" in the iso code from an identical ZAR symbol ("R")

Fixes #132 

