### PR TITLE
Use provided currency over assumed currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.10.0
+- When using the `assume_from_symbol` option, the currency in the input string will be used over the assumed currency based on symbol. For example, `$1.05 CAD` will use `CAD` instead of `USD`.
+
 ## 1.9.4
 - Fix symbol parsing that are surrounded by other characters
 

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -63,8 +63,9 @@ module Monetize
 
     def parse_currency
       computed_currency = nil
-      computed_currency = compute_currency if assume_from_symbol?
-      computed_currency ||= input[/[A-Z]{2,3}/]
+      computed_currency = input[/[A-Z]{2,3}/]
+      computed_currency ||= compute_currency if assume_from_symbol?
+
 
       computed_currency || fallback_currency || Money.default_currency
     end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -118,6 +118,10 @@ describe Monetize do
           expect(Monetize.parse('L9.99')).to eq Money.new(999, 'USD')
         end
 
+        it 'should use provided currency over symbol' do
+          expect(Monetize.parse('$1.05 CAD')).to eq Money.new(105, 'CAD')
+        end
+
         it 'ignores ZAR symbols that is part of a text' do
           expect(Monetize.parse('EUR 9.99')).to eq Money.new(999, 'EUR')
           expect(Monetize.parse('9.99 EUR')).to eq Money.new(999, 'EUR')


### PR DESCRIPTION
It is common to write `$1.09 CAD`. In this case, the provided currency should be used over the computed currency based on the symbol when using the `assume_from_symbol` option.

This pull request prioritizes the currency in the input. If no currency is provided, it still falls back to assuming the currency from the symbol.