### PR TITLE
Update rake dependency to fix vulnerability

### DIFF
--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'money', '~> 6.12'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', '~> 10.2'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
CVE-2020-8130
moderate severity

Vulnerable versions: <= 12.3.2
Patched version: 12.3.3

There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.