### PR TITLE
Raise Monetize::ParseError instead of ArgumentError form BigDecimal

### DIFF
--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -50,7 +50,7 @@ module Monetize
 
       major, minor = extract_major_minor(num, currency)
 
-      amount = BigDecimal([major, minor].join(DEFAULT_DECIMAL_MARK))
+      amount = to_big_decimal([major, minor].join(DEFAULT_DECIMAL_MARK))
       amount = apply_multiplier(multiplier_exp, amount)
       amount = apply_sign(negative, amount)
 
@@ -58,6 +58,12 @@ module Monetize
     end
 
     private
+
+    def to_big_decimal(value)
+      BigDecimal(value)
+    rescue ::ArgumentError => err
+      fail ParseError, err.message
+    end
 
     attr_reader :input, :fallback_currency, :options
 

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -333,6 +333,10 @@ describe Monetize do
     it 'raises ArgumentError when unable to detect polarity' do
       expect { Monetize.parse!('-$5.95-') }.to raise_error Monetize::ParseError
     end
+
+    it 'raises ArgumentError with invalid format' do
+      expect { Monetize.parse!('11..0') }.to raise_error Monetize::ParseError
+    end
   end
 
   describe '.parse_collection' do


### PR DESCRIPTION
Fixes: #145 