### PR TITLE
Current money-rails to_hash is different. Updating to_money to match.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,8 @@ elsif RUBY_VERSION =~ /^1/
   gem 'i18n', '~> 0.9'
 end
 
+group :test do
+  gem 'money-rails', require: false
+end
+
 gemspec

--- a/lib/monetize/core_extensions/hash.rb
+++ b/lib/monetize/core_extensions/hash.rb
@@ -2,7 +2,14 @@
 
 class Hash
   def to_money(currency = nil)
-    hash_currency = self[:currency].is_a?(Hash) ? self[:currency][:iso_code] : self[:currency]
+    hash_currency = if self[:currency].is_a?(Hash)
+                      self[:currency][:iso_code]
+                    elsif self[:currency_iso] && !self[:currency_iso].empty?
+                      self[:currency_iso]
+                    else
+                      self[:currency]
+                    end
+
     Money.new(self[:cents] || self[:fractional], hash_currency || currency || Money.default_currency)
   end
 end

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -230,6 +230,26 @@ describe Monetize, 'core extensions' do
           expect(hash.to_money).to eq(Money.new(100, 'USD'))
         end
       end
+
+      fork {
+        require 'money-rails'
+
+        context 'when Money to_hash is used' do
+          subject(:hash) { Money.new(100, 'SGD').to_hash }
+  
+          it 'converts Hash to Money, interpreting fractional as cents' do
+            expect(hash.to_money).to eq(Money.new(100, 'SGD'))
+          end
+        end
+      }
+
+      context 'ensure money-rails is not loaded' do
+        subject(:hash) { Money.new(100, 'SGD').to_hash }
+
+        it 'is missing to_hash' do
+          expect { hash }.to raise_error NoMethodError
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Maintains loose coupling to money-rails while being directly callable in the spec via `fork`.

If money-rails updates again, we'll know.