### PR TITLE
Improves parsing where fractional subunits are not expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Monetize.parse("£100") == Money.new(100_00, "GBP")
 "€100".to_money == Money.new(100_00, "EUR")
 ```
 
+Parsing can be improved where the input is not expected to contain fractonal subunits.
+To do this, set `Monetize.expect_whole_subunits = true`
+
+```ruby
+Monetize.parse('EUR 10,000') == Money.new(100_00, "EUR")
+
+Monetize.expect_whole_subunits = true
+Monetize.parse('EUR 10,000') == Money.new(10_000_00, "EUR")
+```
+
+Why does this work?  If we expect fractional subunits then the parser will treat a single
+delimiter as a decimal marker if it matches the currency's decimal marker.  But often 
+this is not the case - a European site will show $10.000 because that's the local format.
+As a human, if this was a stock ticker we might expect fractional cents.  If it's a retail price we know it's actually an incorrect thousands separator.
+
+
 Monetize can also parse a list of values, returning an array-like object ([Monetize::Collection](lib/collection.rb)):
 
 ```ruby

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -20,6 +20,12 @@ module Monetize
     # to true to enforce the delimiters set in the currency all the time.
     attr_accessor :enforce_currency_delimiters
 
+
+    # Where this set to true, the behavior for parsing thousands separators is changed to 
+    # expect that eg. €10.000 is EUR 10 000 and not EUR 10.000 - it's incredibly rare when parsing 
+    # human text that we're dealing with fractions of cents.
+    attr_accessor :expect_whole_subunits
+
     def parse(input, currency = Money.default_currency, options = {})
       parse! input, currency, options
     rescue Error

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -344,6 +344,32 @@ describe Monetize do
         expect('€0.5324'.to_money('EU4')).to eq Money.new(5324, 'EU4')
       end
     end
+
+    describe "expecting whole subunits" do
+      before(:all) do 
+        Monetize.expect_whole_subunits = true
+        Monetize.assume_from_symbol = true
+      end
+
+      after(:all) do
+        Monetize.expect_whole_subunits = false
+        Monetize.assume_from_symbol = false
+      end
+
+      it "handles euros" do
+        expect(Monetize.parse('€10,000')).to eq Money.new(10_000_00, 'EUR')
+        expect(Monetize.parse('€10,00')).to eq Money.new(10_00, 'EUR')
+        expect(Monetize.parse('€10.00')).to eq Money.new(10_00, 'EUR')
+        expect(Monetize.parse('EUR 10,000.00')).to eq Money.new(10_000_00, 'EUR')
+      end
+
+      it "handles GBP" do
+        expect(Monetize.parse('£10,000')).to eq Money.new(10_000_00, 'GBP')
+        expect(Monetize.parse('£10.000')).to eq Money.new(10_000_00, 'GBP')
+        expect(Monetize.parse('£10,00')).to eq Money.new(10_00, 'GBP')
+        expect(Monetize.parse('£10.00')).to eq Money.new(10_00, 'GBP')
+      end
+    end
   end
 
   describe '.parse!' do


### PR DESCRIPTION
Parsing real world human input there's a common case where a single thousands separator is used.

For example at the moment, the following string parsings are incorrect (unless we're expecting fractional subunits)

```ruby
Monetize.parse('USD 10.000')  == Money(10_00, 'USD')  # => $10.00
Monetize.parse('EUR 10,050')  == Money(10_05, 'EUR')  # => €10.05
```

Sometimes we expect fractional subunits (stock prices etc) but often we actually don't.  A shopping comparison site will almost never expect fractional subunits.

I have therefore added the `Monetize.expect_whole_subunits` option.   This will corrects the above scenario. 

```ruby
Monetize.expect_whole_subunits = true
Monetize.parse('USD 10.000')  == Money(10_000_00, 'USD')  # => $10 000.00
Monetize.parse('EUR 10,050')  == Money(10_050_00, 'EUR')  # => €10 050.05
```

All specs pass.

