### PR TITLE
[POC] Add a new Strict parser

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -5,11 +5,14 @@ require 'monetize/core_extensions'
 require 'monetize/errors'
 require 'monetize/version'
 require 'monetize/parser'
+require 'monetize/strict_parser'
 require 'monetize/collection'
 
 module Monetize
   # Class methods
   class << self
+    attr_writer :parser_class
+
     # @attr_accessor [true, false] assume_from_symbol Use this to enable the
     #   ability to assume the currency from a passed symbol
     attr_accessor :assume_from_symbol
@@ -20,11 +23,14 @@ module Monetize
     # to true to enforce the delimiters set in the currency all the time.
     attr_accessor :enforce_currency_delimiters
 
-
     # Where this set to true, the behavior for parsing thousands separators is changed to 
     # expect that eg. €10.000 is EUR 10 000 and not EUR 10.000 - it's incredibly rare when parsing 
     # human text that we're dealing with fractions of cents.
     attr_accessor :expect_whole_subunits
+
+    def parser_class
+      @parser_class || Monetize::Parser
+    end
 
     def parse(input, currency = Money.default_currency, options = {})
       parse! input, currency, options
@@ -36,7 +42,7 @@ module Monetize
       return input if input.is_a?(Money)
       return from_numeric(input, currency) if input.is_a?(Numeric)
 
-      parser = Monetize::Parser.new(input, currency, options)
+      parser = parser_class.new(input, currency, options)
       amount, currency = parser.parse
 
       Money.from_amount(amount, currency)
@@ -79,3 +85,5 @@ module Monetize
     end
   end
 end
+
+Monetize.parser_class = Monetize::StrictParser

--- a/lib/monetize/strict_parser.rb
+++ b/lib/monetize/strict_parser.rb
@@ -1,0 +1,118 @@
+require 'monetize/parser'
+require 'monetize/tokenizer'
+
+module Monetize
+  class StrictParser
+    # TODO: perform exhaustive match
+    # TODO: error subclasses with detailed explanation
+    # TODO: check if decimal mark is a thousands separator (1,000 USD)
+    # TODO: switch to using allowed format as strings for added flexibility
+
+    def initialize(input, fallback_currency = Money.default_currency, options = {})
+      @input = input.to_s
+      @options = options
+      @fallback_currency = fallback_currency
+    end
+
+    def parse
+      result = Tokenizer.new(input, options).process
+
+      unless ALLOWED_FORMATS.include?(result.map(&:first))
+        raise ParseError, "invalid input - #{result.map(&:first)}"
+      end
+
+      amount = result.find { |token| token.type == :amount }
+      sign = result.find { |token| token.type == :sign }
+      symbol = result.find { |token| token.type == :symbol }
+      currency_iso = result.find { |token| token.type == :currency_iso }
+
+      currency =
+        if currency_iso
+          parse_currency_iso(currency_iso.match.to_s)
+        elsif symbol && assume_from_symbol?
+          parse_symbol(symbol.match.to_s)
+        else
+          fallback_currency
+        end
+
+      amount = parse_amount(currency, amount.match, sign&.match)
+
+      [amount, currency]
+    end
+
+    private
+
+    ALLOWED_FORMATS = [
+      [:amount],                                # 9.99
+      [:sign, :amount],                         # -9.99
+      [:symbol, :amount],                       # £9.99
+      [:sign, :symbol, :amount],                # -£9.99
+      [:symbol, :sign, :amount],                # £-9.99
+      [:symbol, :amount, :sign],                # £9.99-
+      [:amount, :symbol],                       # 9.99£
+      [:sign, :amount, :symbol],                # -9.99£
+      [:currency_iso, :amount],                 # GBP 9.99
+      [:currency_iso, :sign, :amount],          # GBP -9.99
+      [:amount, :currency_iso],                 # 9.99 GBP
+      [:sign, :amount, :currency_iso],          # -9.99 GBP
+      [:symbol, :amount, :currency_iso],        # £9.99 GBP
+      [:sign, :symbol, :amount, :currency_iso], # -£9.99 GBP
+    ].freeze
+
+    attr_reader :input, :fallback_currency, :options
+
+    def parse_amount(currency, amount, sign)
+      multiplier = amount[:multiplier]
+      amount = amount[:amount].gsub(' ', '')
+
+      used_delimiters = amount.scan(/[^\d]/).uniq
+
+      num =
+        case used_delimiters.length
+        when 0
+          amount.to_f
+        when 1
+          decimal_mark = used_delimiters.first
+          amount = amount.gsub(decimal_mark, '.')
+
+          amount.to_f
+        when 2
+          thousands_separator, decimal_mark = used_delimiters
+          amount = amount.gsub(thousands_separator, '')
+          amount = amount.gsub(decimal_mark, '.')
+
+          amount.to_f
+        else
+          raise ParseError, 'invalid amount of delimiters used'
+        end
+
+      num = apply_multiplier(num, multiplier)
+      num = apply_sign(num, sign.to_s)
+
+      num
+    end
+
+    def parse_symbol(symbol)
+      Money::Currency.wrap(Monetize::Parser::CURRENCY_SYMBOLS[symbol])
+    end
+
+    def parse_currency_iso(currency_iso)
+      Money::Currency.wrap(currency_iso)
+    end
+
+    def assume_from_symbol?
+      options.fetch(:assume_from_symbol) { Monetize.assume_from_symbol }
+    end
+
+    def apply_multiplier(num, multiplier)
+      return num unless multiplier
+
+      exponent = Monetize::Parser::MULTIPLIER_SUFFIXES[multiplier.to_s.upcase]
+      num * 10**exponent
+    end
+
+    def apply_sign(num, sign)
+      sign == '-' ? num * -1 : num
+    end
+  end
+end

--- a/lib/monetize/tokenizer.rb
+++ b/lib/monetize/tokenizer.rb
@@ -1,0 +1,71 @@
+require 'monetize/parser'
+
+module Monetize
+  class Tokenizer
+    SYMBOLS = Monetize::Parser::CURRENCY_SYMBOLS.keys.map { |symbol| Regexp.escape(symbol) }.freeze
+    THOUSAND_SEPARATORS = /[\.\ ,]/.freeze
+    DECIMAL_MARKS = /[\.,]/.freeze
+    MULTIPLIERS = Monetize::Parser::MULTIPLIER_SUFFIXES.keys.join('|').freeze
+
+    SYMBOL_REGEXP = Regexp.new(SYMBOLS.join('|')).freeze
+    CURRENCY_ISO_REGEXP = /(?<![A-Z])[A-Z]{3}(?![A-Z])/i.freeze
+    SIGN_REGEXP = /[\-\+]/.freeze
+    AMOUNT_REGEXP = %r{
+      (?<amount>                         # amount group
+        \d+                              # starts with at least one digit
+        (?:#{THOUSAND_SEPARATORS}\d{3})* # separated into groups of 3 digits by a thousands separator
+        (?!\d)                           # not followed by a digit
+        (?:#{DECIMAL_MARKS}\d+)?         # has decimal mark followed by decimal part
+      )
+      (?<multiplier>#{MULTIPLIERS})?     # optional multiplier
+    }ix.freeze
+
+    class Token < Struct.new(:type, :match); end
+
+    def initialize(input, options = {})
+      @original_input = input
+      @options = options
+    end
+
+    def process
+      # matches are removed from the input string to avoid overlapping matches
+      input = original_input.dup
+      result = []
+
+      result += match(input, :currency_iso, CURRENCY_ISO_REGEXP)
+      result += match(input, :symbol, SYMBOL_REGEXP)
+      result += match(input, :sign, SIGN_REGEXP)
+      result += match(input, :amount, AMOUNT_REGEXP)
+
+      result.sort_by { |token| token.match.offset(0).first }
+    end
+
+    private
+
+    attr_reader :original_input, :options
+
+    def match(input, type, regexp)
+      tokens = []
+      input.scan(regexp) { tokens << Token.new(type, Regexp.last_match) }
+
+      # Replace the matches from the input with § to avoid over-matching
+      tokens.each do |token|
+        offset = token.match.offset(0)
+        input[offset.first..(offset.last - 1)] = '§' * token.match.to_s.length
+      end
+
+      tokens
+    end
+
+    def preview(result)
+      preview_input = original_input.dup
+      result.reverse.each do |token|
+        offset = token.match.offset(0)
+        preview_input.slice!(offset.first, token.match.to_s.length)
+        preview_input.insert(offset.first, "<#{token.type}>")
+      end
+
+      puts preview_input
+    end
+  end
+end


### PR DESCRIPTION
⚠️ Not yet ready to be merged ⚠️

Opening this PR to start a discussion on the current approach to parsing.

Over time I have worked/consulted for a few companies that use this gem internally. However all of them had to monkey-patch the gem in order to significantly restrict string parsing (especially when it comes to user input and even developer input).

The main issues being:

1. Some wrong inputs get treated as amounts (e.g. `29.01.2023`, `29,12,12`, etc)
2. Extra symbols are simply ignored (instead of suggesting incorrect input, e.g. `one1two2three3`)
3. Loose thousands separator and decimal mark matching (`10,000` and `10,00` yield different results)

I think that the current approach is "find any signs of monetary amount in the input". While this works for some use-cases, I would argue that this might not be the best default behaviour. For any company providing financial services or even consumer retail this unfortunately is straight unacceptable.

Therefore I'm proposing adding an optional strict parser (and potentially making it default). This parser takes a different approach — it finds known good partial matches (currency, symbol, amount, etc) and then checks it against allowed formats (e.g. `[:symbol, :amount]` for `$99.99`). This allows gem users to ensure that only allowed formats are matched and no unwanted characters were present.

The PR is a proof of concept and passes most specs with expected exceptions related specifically to:

- Matching `€10,000` as 10K, instead of 10 (should be tweak-able)
- Not matching `£.45B` as this is a rarely accepted format
- Returning `nil` when parsing `nil` (happy to change this to `Money.empty`)
- Not matching `19.12.89` as this doesn't look like an amount

This is a big(ish) change, so I'd like to gather more input from others before I make further progress.

Any questions, concerns and feedback is very welcome! 🙌 