### PR TITLE
Parse currency correctly if found from existing hash

### DIFF
--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -76,6 +76,7 @@ module Monetize
     def parse_currency
       computed_currency = nil
       computed_currency = input[/[A-Z]{2,3}/]
+      computed_currency = nil unless Monetize::Parser::CURRENCY_SYMBOLS.value?(computed_currency)
       computed_currency ||= compute_currency if assume_from_symbol?
 
 
@@ -132,7 +133,7 @@ module Monetize
           extract_major_minor_with_tentative_delimiter(num, delimiter)
         end
       else
-        if delimiter == currency.decimal_mark 
+        if delimiter == currency.decimal_mark
           split_major_minor(num, delimiter)
         elsif Monetize.enforce_currency_delimiters && delimiter == currency.thousands_separator
           [num.gsub(delimiter, ''), 0]

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -172,8 +172,28 @@ describe Monetize do
           expect('20.00 GBP'.to_money).to eq Money.new(20_00, 'GBP')
         end
 
-        it 'raises an error if currency code is invalid' do
-          expect { '20.00 OMG'.to_money }.to raise_error Monetize::ParseError
+        context 'with default currency' do
+          before do
+            Money.default_currency = Money::Currency.new('USD')
+          end
+
+          it 'parses currency given using default currency' do
+            expect('20.00 OMG'.to_money).to eq Money.new(20_00, 'USD')
+          end
+        end
+
+        context 'without default currency' do
+          before do
+            Money.default_currency = nil
+          end
+
+          after do
+            Money.default_currency = Money::Currency.new('USD')
+          end
+
+          it 'raises an error if currency code is invalid' do
+            expect { '20.00 OMG'.to_money }.to raise_error
+          end
         end
       end
     end
@@ -346,7 +366,7 @@ describe Monetize do
     end
 
     describe "expecting whole subunits" do
-      before(:all) do 
+      before(:all) do
         Monetize.expect_whole_subunits = true
         Monetize.assume_from_symbol = true
       end


### PR DESCRIPTION
- Fix parsing issue for certain currency symbols like Malaysia Ringgit (RM) as addressed in https://github.com/RubyMoney/monetize/issues/153 by checking that 
    - the `computed_currency` parsed from the given input from a match ISO currency code regex is a correct ISO code from existing `Monetize::Parser::CURRENCY_SYMBOLS`, then only assigned it with value
    - else fallback to use `compute_currency` which match against currency symbol regex
    - eg:
    ```rb
    "RM100".to_money    # #<Money fractional:10000 currency:MYR>
    "S$100".to_money    # #<Money fractional:10000 currency:SGD>
    "NT$100".to_money   # #<Money fractional:10000 currency:TWD>
    "HK$100".to_money   # #<Money fractional:10000 currency:HKD>
    "$100 CAD".to_money # #<Money fractional:10000 currency:CAD>
    ```
- Add & fix related rspecs
