### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
     spec.metadata['changelog_uri'] = 'https://github.com/RubyMoney/monetize/blob/master/CHANGELOG.md'
     spec.metadata['source_code_uri'] = 'https://github.com/RubyMoney/monetize/'
     spec.metadata['bug_tracker_uri'] = 'https://github.com/RubyMoney/monetize/issues'
+    spec.metadata['rubygems_mfa_required'] = 'true'
   end
 end


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/