### PR TITLE
Fix bug introduced by PR#167 not covering all available currencies

### DIFF
--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -109,7 +109,11 @@ describe Monetize do
             end
 
             it 'parses formatted inputs without currency detection when overridden' do
-              expect(Monetize.parse("#{symbol}5.95", nil, assume_from_symbol: false)).to eq Money.new(amount, 'USD')
+              currency_symbols_with_no_special_and_uncapitalized_chars = ["RM"]
+
+              expect(Monetize.parse("#{symbol}5.95", nil, assume_from_symbol: false)).to eq(
+                Money.new(amount, currency_symbols_with_no_special_and_uncapitalized_chars.include?(symbol) ? iso_code : "USD")
+              )
             end
           end
         end


### PR DESCRIPTION
Currently, there is an existing bug in `monetize` v1.13.0 introduced by https://github.com/RubyMoney/monetize/pull/167 that attempted to implement additional logic for currency parsing discussed in https://github.com/RubyMoney/monetize/issues/153.
 
Example of the bug:
- Expected:
```
"RM100".to_money    # #<Money fractional:10000 currency:MYR>
Monetize.parse("RM100")   # #<Money fractional:10000 currency:MYR>
Monetize.parse("100 RM")   # #<Money fractional:10000 currency:MYR>
```
- Reality:
```
[1] pry(main)> Monetize.parse("RM100")
=> #<Money fractional:10000 currency:USD>

[8] pry(main)> "RM100".to_money
=> #<Money fractional:10000 currency:USD>

[14] pry(main)> Monetize.parse("100 RM")
=> #<Money fractional:10000 currency:USD>
```

This PR aims to:
- Fix that bug.
- Implement the additional currency parsing logic in https://github.com/RubyMoney/monetize/issues/153.
- Improve parsing logic in general by validating parsed currency input against `Money::Currency.all.map(&:iso_code)`.
- Update `spec/monetize_spec.rb` to accommodate for the aforementioned changes.