### PR TITLE
Relax rake version constraint

### DIFF
--- a/monetize.gemspec
+++ b/monetize.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'money', '~> 6.12'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', '~> 10.2'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
There's some weird version compatibility issue with Ruby 3.1+ and older `rake`:

```
rake aborted!
NoMethodError: undefined method `=~' for an instance of Proc
```

It might be my setup, but I wasn't able to track down what exactly is causing this. New `rake` doesn't have this issue and since `money` gem also doesn't impose this constraint, probably no point to do it here either.