### PR TITLE
Support for multiple parsers

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -4,7 +4,7 @@ require 'money'
 require 'monetize/core_extensions'
 require 'monetize/errors'
 require 'monetize/version'
-require 'monetize/parser'
+require 'monetize/optimistic_parser'
 require 'monetize/collection'
 
 module Monetize
@@ -36,7 +36,7 @@ module Monetize
       return input if input.is_a?(Money)
       return from_numeric(input, currency) if input.is_a?(Numeric)
 
-      parser = Monetize::Parser.new(input, currency, options)
+      parser = Monetize::OptimisticParser.new(input, currency, options)
       amount, currency = parser.parse
 
       Money.from_amount(amount, currency)

--- a/lib/monetize/optimistic_parser.rb
+++ b/lib/monetize/optimistic_parser.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 module Monetize
-  class Parser
+  class OptimisticParser
     CURRENCY_SYMBOLS = {
       '$'  => 'USD',
       '€'  => 'EUR',
@@ -76,7 +76,7 @@ module Monetize
     def parse_currency
       computed_currency = nil
       computed_currency = input[/[A-Z]{2,3}/]
-      computed_currency = nil unless Monetize::Parser::CURRENCY_SYMBOLS.value?(computed_currency)
+      computed_currency = nil unless Monetize::OptimisticParser::CURRENCY_SYMBOLS.value?(computed_currency)
       computed_currency ||= compute_currency if assume_from_symbol?
 
 

--- a/lib/monetize/optimistic_parser.rb
+++ b/lib/monetize/optimistic_parser.rb
@@ -8,7 +8,7 @@ module Monetize
 
     DEFAULT_DECIMAL_MARK = '.'.freeze
 
-    def initialize(input, fallback_currency = Money.default_currency, options = {})
+    def initialize(input, fallback_currency, options)
       @input = input.to_s.strip
       @fallback_currency = fallback_currency
       @options = options

--- a/lib/monetize/optimistic_parser.rb
+++ b/lib/monetize/optimistic_parser.rb
@@ -1,38 +1,9 @@
 # encoding: utf-8
 
-module Monetize
-  class OptimisticParser
-    CURRENCY_SYMBOLS = {
-      '$'  => 'USD',
-      '€'  => 'EUR',
-      '£'  => 'GBP',
-      '₤'  => 'GBP',
-      'R$' => 'BRL',
-      'RM' => 'MYR',
-      'Rp' => 'IDR',
-      'R'  => 'ZAR',
-      '¥'  => 'JPY',
-      'C$' => 'CAD',
-      '₼'  => 'AZN',
-      '元' => 'CNY',
-      'Kč' => 'CZK',
-      'Ft' => 'HUF',
-      '₹'  => 'INR',
-      '₽'  => 'RUB',
-      '₺'  => 'TRY',
-      '₴'  => 'UAH',
-      'Fr' => 'CHF',
-      'zł' => 'PLN',
-      '₸'  => 'KZT',
-      "₩"  => 'KRW',
-      'S$' => 'SGD',
-      'HK$'=> 'HKD',
-      'NT$'=> 'TWD',
-      '₱'  => 'PHP',
-    }
+require 'monetize/parser'
 
-    MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
-    MULTIPLIER_SUFFIXES.default = 0
+module Monetize
+  class OptimisticParser < Parser
     MULTIPLIER_REGEXP = Regexp.new(format('^(.*?\d)(%s)\b([^\d]*)$', MULTIPLIER_SUFFIXES.keys.join('|')), 'i')
 
     DEFAULT_DECIMAL_MARK = '.'.freeze
@@ -76,7 +47,7 @@ module Monetize
     def parse_currency
       computed_currency = nil
       computed_currency = input[/[A-Z]{2,3}/]
-      computed_currency = nil unless Monetize::OptimisticParser::CURRENCY_SYMBOLS.value?(computed_currency)
+      computed_currency = nil unless CURRENCY_SYMBOLS.value?(computed_currency)
       computed_currency ||= compute_currency if assume_from_symbol?
 
 

--- a/lib/monetize/optimistic_parser.rb
+++ b/lib/monetize/optimistic_parser.rb
@@ -36,13 +36,15 @@ module Monetize
 
     private
 
+    private
+
+    attr_reader :input, :fallback_currency, :options
+
     def to_big_decimal(value)
       BigDecimal(value)
     rescue ::ArgumentError => err
       fail ParseError, err.message
     end
-
-    attr_reader :input, :fallback_currency, :options
 
     def parse_currency
       computed_currency = nil

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+
+module Monetize
+  class Parser
+    CURRENCY_SYMBOLS = {
+      '$'  => 'USD',
+      '€'  => 'EUR',
+      '£'  => 'GBP',
+      '₤'  => 'GBP',
+      'R$' => 'BRL',
+      'RM' => 'MYR',
+      'Rp' => 'IDR',
+      'R'  => 'ZAR',
+      '¥'  => 'JPY',
+      'C$' => 'CAD',
+      '₼'  => 'AZN',
+      '元' => 'CNY',
+      'Kč' => 'CZK',
+      'Ft' => 'HUF',
+      '₹'  => 'INR',
+      '₽'  => 'RUB',
+      '₺'  => 'TRY',
+      '₴'  => 'UAH',
+      'Fr' => 'CHF',
+      'zł' => 'PLN',
+      '₸'  => 'KZT',
+      "₩"  => 'KRW',
+      'S$' => 'SGD',
+      'HK$'=> 'HKD',
+      'NT$'=> 'TWD',
+      '₱'  => 'PHP',
+    }
+
+    MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
+    MULTIPLIER_SUFFIXES.default = 0
+  end
+end

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -34,7 +34,7 @@ module Monetize
     MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
     MULTIPLIER_SUFFIXES.default = 0
 
-    def initialize(input, fallback_currency = Money.default_currency, options = {})
+    def initialize(input, fallback_currency, options)
       raise NotImplementedError, 'Monetize::Parser subclasses must implement #initialize'
     end
 

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -33,5 +33,13 @@ module Monetize
 
     MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
     MULTIPLIER_SUFFIXES.default = 0
+
+    def initialize(input, fallback_currency = Money.default_currency, options = {})
+      raise NotImplementedError, 'Monetize::Parser subclasses must implement #initialize'
+    end
+
+    def parse
+      raise NotImplementedError, 'Monetize::Parser subclasses must implement #parse'
+    end
   end
 end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -36,6 +36,17 @@ describe Monetize do
     }
   JSON
 
+  # Dummy parser that always returns an amount and currency specified via options
+  class TestParser < Monetize::Parser
+    def initialize(input, currency, options)
+      @options = options
+    end
+
+    def parse
+      [@options[:amount], @options[:currency]]
+    end
+  end
+
   describe '.parse' do
     it 'parses european-formatted inputs under 10EUR' do
       expect(Monetize.parse('EUR 5,95')).to eq Money.new(595, 'EUR')
@@ -390,6 +401,12 @@ describe Monetize do
         expect(Monetize.parse('£10.00')).to eq Money.new(10_00, 'GBP')
       end
     end
+
+    context 'when specified parser does not exist' do
+      it 'returns nil' do
+        expect(Monetize.parse('100 USD', nil, parser: :foo)).to eq(nil)
+      end
+    end
   end
 
   describe '.parse!' do
@@ -405,6 +422,14 @@ describe Monetize do
 
     it 'raises ArgumentError with invalid format' do
       expect { Monetize.parse!('11..0') }.to raise_error Monetize::ParseError
+    end
+
+    context 'when specified parser does not exist' do
+      it 'raises ArgumentError' do
+        expect do
+          Monetize.parse!('100 USD', nil, parser: :foo)
+        end.to raise_error(Monetize::ArgumentError, 'Parser not registered: foo')
+      end
     end
   end
 
@@ -628,6 +653,41 @@ describe Monetize do
   context 'given the same inputs to .parse and .from_*' do
     it 'gives the same results' do
       expect(4.635.to_money).to eq '4.635'.to_money
+    end
+  end
+
+  describe '.register_parser' do
+    it 'registers a new parser with a provided name' do
+      Monetize.register_parser(:test, TestParser, amount: 42, currency: 'GBP')
+
+      expect(Monetize.parse!('test', nil, parser: :test)).to eq(Money.new(42_00, 'GBP'))
+    end
+
+    it 'registers the same parser with a different name' do
+      Monetize.register_parser(:test_1, TestParser, amount: 1, currency: 'GBP')
+      Monetize.register_parser(:test_2, TestParser, amount: 2, currency: 'USD')
+
+      expect(Monetize.parse!('test', nil, parser: :test_1)).to eq(Money.new(1_00, 'GBP'))
+      expect(Monetize.parse!('test', nil, parser: :test_2)).to eq(Money.new(2_00, 'USD'))
+    end
+
+    it 'overrides existing parser with the same name' do
+      Monetize.register_parser(:test, TestParser, amount: 42, currency: 'GBP')
+      Monetize.register_parser(:test, TestParser, amount: 99, currency: 'USD')
+
+      expect(Monetize.parse!('test', nil, parser: :test)).to eq(Money.new(99_00, 'USD'))
+    end
+  end
+
+  describe '.default_parser=' do
+    before { Monetize.register_parser(:test, TestParser, amount: 1, currency: 'USD') }
+    after { Monetize.default_parser = :optimistic }
+
+    it 'specifies which parser to use by default' do
+      expect(Monetize.parse!('99 GBP')).to eq(Money.new(99_00, 'GBP'))
+
+      Monetize.default_parser = :test
+      expect(Monetize.parse!('99 GBP')).to eq(Money.new(1_00, 'USD'))
     end
   end
 end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -56,7 +56,7 @@ describe Monetize do
           Monetize.assume_from_symbol = false
         end
 
-        Monetize::Parser::CURRENCY_SYMBOLS.each_pair do |symbol, iso_code|
+        Monetize::OptimisticParser::CURRENCY_SYMBOLS.each_pair do |symbol, iso_code|
           context iso_code do
             let(:currency) { Money::Currency.find(iso_code) }
             let(:amount) { 5_95 }


### PR DESCRIPTION
Resurrecting a previous proposal — https://github.com/RubyMoney/monetize/pull/164

This is basically a step 1 that allows multiple parsers to co-exist without breaking the default behaviour. A new parser is registered under a specified name and then can either be used explicitly by providing `:parser` option to the `Monetize.parse` or implicitly by setting the `Monetize.default_parser`.

The change here should be pretty straightforward, the bulk of it is moving the current parser to `optimistic_parser.rb`, reserving the `parser.rb` for the interface definition.

I've kept the diff as tight as possible, however I feel that a worthy addition would be to change the semantics of a parser class slightly. Right now it represents a parsing of a single input, meaning that a unique class gets created every time `.parse` is called. There aren't lots of benefits to this design besides easy access to the input and options supplied to the `Monetize.parse` (which creates some confusion in the current parser as `input` is mostly shadowed anyways). An alternative would be to treat the parser class as a pre-configured parser ready to parse a given input.

In the next PR I'll bring the `StrictParser` in, which will allow us to release it and gather feedback.

As a side note — given that `monetize` is mostly a parser with a few smaller additions I wonder if the strict parser should be a separate gem altogether assuming most people would want to use one parser across their codebases. This also allows for a super speedy strict parser gem written in Rust or C (which you don't want to impose on people already using `monetize`, because it adds installation time dependencies). We can discuss this later, just something to keep in mind.