### PR TITLE
Implement Strict parser

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,3 +32,5 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rspec spec
+    - name: Run strict tests
+      run: MODE=strict bundle exec rspec spec

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -5,6 +5,7 @@ require 'monetize/core_extensions'
 require 'monetize/errors'
 require 'monetize/version'
 require 'monetize/optimistic_parser'
+require 'monetize/strict_parser'
 require 'monetize/collection'
 
 module Monetize
@@ -105,4 +106,5 @@ module Monetize
 end
 
 Monetize.register_parser(:optimistic, Monetize::OptimisticParser)
+Monetize.register_parser(:strict, Monetize::StrictParser)
 Monetize.default_parser = :optimistic

--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -4,7 +4,7 @@ require 'money'
 require 'monetize/core_extensions'
 require 'monetize/errors'
 require 'monetize/version'
-require 'monetize/parser'
+require 'monetize/optimistic_parser'
 require 'monetize/collection'
 
 module Monetize
@@ -36,7 +36,7 @@ module Monetize
       return input if input.is_a?(Money)
       return from_numeric(input, currency) if input.is_a?(Numeric)
 
-      parser = Monetize::Parser.new(input, currency, options)
+      parser = Monetize::OptimisticParser.new(input, currency, options)
       amount, currency = parser.parse
 
       Money.from_amount(amount, currency)

--- a/lib/monetize/optimistic_parser.rb
+++ b/lib/monetize/optimistic_parser.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 module Monetize
-  class Parser
+  class OptimisticParser
     CURRENCY_SYMBOLS = {
       '$'  => 'USD',
       '€'  => 'EUR',
@@ -76,7 +76,7 @@ module Monetize
     def parse_currency
       computed_currency = nil
       computed_currency = input[/[A-Z]{2,3}/]
-      computed_currency = nil unless Monetize::Parser::CURRENCY_SYMBOLS.value?(computed_currency)
+      computed_currency = nil unless Monetize::OptimisticParser::CURRENCY_SYMBOLS.value?(computed_currency)
       computed_currency ||= compute_currency if assume_from_symbol?
 
 

--- a/lib/monetize/optimistic_parser.rb
+++ b/lib/monetize/optimistic_parser.rb
@@ -8,7 +8,7 @@ module Monetize
 
     DEFAULT_DECIMAL_MARK = '.'.freeze
 
-    def initialize(input, fallback_currency = Money.default_currency, options = {})
+    def initialize(input, fallback_currency, options)
       @input = input.to_s.strip
       @fallback_currency = fallback_currency
       @options = options

--- a/lib/monetize/optimistic_parser.rb
+++ b/lib/monetize/optimistic_parser.rb
@@ -1,38 +1,9 @@
 # encoding: utf-8
 
-module Monetize
-  class OptimisticParser
-    CURRENCY_SYMBOLS = {
-      '$'  => 'USD',
-      '€'  => 'EUR',
-      '£'  => 'GBP',
-      '₤'  => 'GBP',
-      'R$' => 'BRL',
-      'RM' => 'MYR',
-      'Rp' => 'IDR',
-      'R'  => 'ZAR',
-      '¥'  => 'JPY',
-      'C$' => 'CAD',
-      '₼'  => 'AZN',
-      '元' => 'CNY',
-      'Kč' => 'CZK',
-      'Ft' => 'HUF',
-      '₹'  => 'INR',
-      '₽'  => 'RUB',
-      '₺'  => 'TRY',
-      '₴'  => 'UAH',
-      'Fr' => 'CHF',
-      'zł' => 'PLN',
-      '₸'  => 'KZT',
-      "₩"  => 'KRW',
-      'S$' => 'SGD',
-      'HK$'=> 'HKD',
-      'NT$'=> 'TWD',
-      '₱'  => 'PHP',
-    }
+require 'monetize/parser'
 
-    MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
-    MULTIPLIER_SUFFIXES.default = 0
+module Monetize
+  class OptimisticParser < Parser
     MULTIPLIER_REGEXP = Regexp.new(format('^(.*?\d)(%s)\b([^\d]*)$', MULTIPLIER_SUFFIXES.keys.join('|')), 'i')
 
     DEFAULT_DECIMAL_MARK = '.'.freeze
@@ -76,7 +47,7 @@ module Monetize
     def parse_currency
       computed_currency = nil
       computed_currency = input[/[A-Z]{2,3}/]
-      computed_currency = nil unless Monetize::OptimisticParser::CURRENCY_SYMBOLS.value?(computed_currency)
+      computed_currency = nil unless CURRENCY_SYMBOLS.value?(computed_currency)
       computed_currency ||= compute_currency if assume_from_symbol?
 
 

--- a/lib/monetize/optimistic_parser.rb
+++ b/lib/monetize/optimistic_parser.rb
@@ -36,13 +36,15 @@ module Monetize
 
     private
 
+    private
+
+    attr_reader :input, :fallback_currency, :options
+
     def to_big_decimal(value)
       BigDecimal(value)
     rescue ::ArgumentError => err
       fail ParseError, err.message
     end
-
-    attr_reader :input, :fallback_currency, :options
 
     def parse_currency
       computed_currency = nil

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+
+module Monetize
+  class Parser
+    CURRENCY_SYMBOLS = {
+      '$'  => 'USD',
+      '€'  => 'EUR',
+      '£'  => 'GBP',
+      '₤'  => 'GBP',
+      'R$' => 'BRL',
+      'RM' => 'MYR',
+      'Rp' => 'IDR',
+      'R'  => 'ZAR',
+      '¥'  => 'JPY',
+      'C$' => 'CAD',
+      '₼'  => 'AZN',
+      '元' => 'CNY',
+      'Kč' => 'CZK',
+      'Ft' => 'HUF',
+      '₹'  => 'INR',
+      '₽'  => 'RUB',
+      '₺'  => 'TRY',
+      '₴'  => 'UAH',
+      'Fr' => 'CHF',
+      'zł' => 'PLN',
+      '₸'  => 'KZT',
+      "₩"  => 'KRW',
+      'S$' => 'SGD',
+      'HK$'=> 'HKD',
+      'NT$'=> 'TWD',
+      '₱'  => 'PHP',
+    }
+
+    MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
+    MULTIPLIER_SUFFIXES.default = 0
+  end
+end

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -34,7 +34,7 @@ module Monetize
     MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
     MULTIPLIER_SUFFIXES.default = 0
 
-    def initialize(input, fallback_currency = Money.default_currency, options = {})
+    def initialize(input, fallback_currency, options)
       raise NotImplementedError, 'Monetize::Parser subclasses must implement #initialize'
     end
 

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -33,5 +33,13 @@ module Monetize
 
     MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
     MULTIPLIER_SUFFIXES.default = 0
+
+    def initialize(input, fallback_currency = Money.default_currency, options = {})
+      raise NotImplementedError, 'Monetize::Parser subclasses must implement #initialize'
+    end
+
+    def parse
+      raise NotImplementedError, 'Monetize::Parser subclasses must implement #parse'
+    end
   end
 end

--- a/lib/monetize/strict_parser.rb
+++ b/lib/monetize/strict_parser.rb
@@ -48,21 +48,19 @@ module Monetize
         raise ParseError, "invalid input - #{tokens.map(&:first)}"
       end
 
-      amount = tokens.find { |token| token.type == :amount }
-      sign = tokens.find { |token| token.type == :sign }
-      symbol = tokens.find { |token| token.type == :symbol }
-      currency_iso = tokens.find { |token| token.type == :currency_iso }
+      parts = Struct.new(:amount, :sign, :symbol, :currency_iso).new
+      tokens.each { |token| parts[token.type] = token }
 
       currency =
-        if currency_iso
-          parse_currency_iso(currency_iso.match.to_s)
-        elsif symbol && assume_from_symbol?
-          parse_symbol(symbol.match.to_s)
+        if parts.currency_iso
+          parse_currency_iso(parts.currency_iso.match.to_s)
+        elsif parts.symbol && assume_from_symbol?
+          parse_symbol(parts.symbol.match.to_s)
         else
           fallback_currency
         end
 
-      amount = parse_amount(currency, amount.match, sign&.match)
+      amount = parse_amount(currency, parts.amount.match, parts.sign&.match)
 
       [amount, currency]
     end

--- a/lib/monetize/strict_parser.rb
+++ b/lib/monetize/strict_parser.rb
@@ -2,6 +2,9 @@ require 'monetize/parser'
 require 'monetize/tokenizer'
 
 module Monetize
+  # Unlike the OptimisticParser which aims for the best effort match, the StrictParser is
+  # designed to only parse well formatted inputs (see ALLOWED_FORMATS) and ignore anything
+  # that looks off.
   class StrictParser < Parser
     # TODO: switch to using allowed format as strings for added flexibility
 

--- a/lib/monetize/strict_parser.rb
+++ b/lib/monetize/strict_parser.rb
@@ -1,0 +1,152 @@
+require 'monetize/parser'
+require 'monetize/tokenizer'
+
+module Monetize
+  class StrictParser < Parser
+    # TODO: perform exhaustive match
+    # TODO: error subclasses with detailed explanation
+    # TODO: check if decimal mark is a thousands separator (1,000 USD)
+    # TODO: switch to using allowed format as strings for added flexibility
+
+    # Some advanced regexp tips to understand the next bit of code:
+    # "?:"       - makes the group non-capturing, excluding it from the resulting match data
+    # "?<name>"  - creates a named capture
+    # "\k<name>" - backreferences a named capture
+    # "?!"       - negative lookahead (next character(-s) can't be the contents of this group)
+    AMOUNT_REGEXP = %r{
+      ^
+        (?:                          # whole units
+          (?:                        # try to capture units separated by thousands
+            \d{1,3}                  # must start with 3 or less whole numbers
+            (?:(?<ts>[\.\ ,])\d{3})?   # first occurance of separated thousands, captures the separator
+            (?:\k<ts>\d{3})*         # other iterations with a backreference to the first separator
+          )
+          |\d+                       # fallback to non thousands-separated units
+        )
+        (?:                          # this group captures subunits
+          (?!\k<ts>)                 # avoid thousands separator used to separate decimals
+          (?<ds>[\.,])               # captured decimal separator
+          \d+                        # subunits
+        )?
+      $
+    }ix.freeze
+
+    def initialize(input, fallback_currency = Money.default_currency, options = {})
+      @input = input.to_s
+      @options = options
+      @fallback_currency = Money::Currency.wrap(fallback_currency)
+      # This shouldn't be here, however String#to_money defaults currency to nil. Ideally we want
+      # the default to always be Money.default_currency unless specified. In that case an explicit
+      # nil would indicate that the currency must be determined from the input.
+      @fallback_currency ||= Money.default_currency
+    end
+
+    def parse
+      result = Tokenizer.new(input, options).process
+
+      unless ALLOWED_FORMATS.include?(result.map(&:first))
+        raise ParseError, "invalid input - #{result.map(&:first)}"
+      end
+
+      amount = result.find { |token| token.type == :amount }
+      sign = result.find { |token| token.type == :sign }
+      symbol = result.find { |token| token.type == :symbol }
+      currency_iso = result.find { |token| token.type == :currency_iso }
+
+      currency =
+        if currency_iso
+          parse_currency_iso(currency_iso.match.to_s)
+        elsif symbol && assume_from_symbol?
+          parse_symbol(symbol.match.to_s)
+        else
+          fallback_currency
+        end
+
+      amount = parse_amount(currency, amount.match, sign&.match)
+
+      [amount, currency]
+    end
+
+    private
+
+    ALLOWED_FORMATS = [
+      [:amount],                                # 9.99
+      [:sign, :amount],                         # -9.99
+      [:symbol, :amount],                       # £9.99
+      [:sign, :symbol, :amount],                # -£9.99
+      [:symbol, :sign, :amount],                # £-9.99
+      [:symbol, :amount, :sign],                # £9.99-
+      [:amount, :symbol],                       # 9.99£
+      [:sign, :amount, :symbol],                # -9.99£
+      [:currency_iso, :amount],                 # GBP 9.99
+      [:currency_iso, :sign, :amount],          # GBP -9.99
+      [:amount, :currency_iso],                 # 9.99 GBP
+      [:sign, :amount, :currency_iso],          # -9.99 GBP
+      [:symbol, :amount, :currency_iso],        # £9.99 GBP
+      [:sign, :symbol, :amount, :currency_iso], # -£9.99 GBP
+    ].freeze
+
+    attr_reader :input, :fallback_currency, :options
+
+    def parse_amount(currency, amount_match, sign)
+      amount = amount_match[:amount]
+      multiplier = amount_match[:multiplier]
+
+      matches = amount.match(AMOUNT_REGEXP)
+
+      unless matches
+        raise ParseError, 'the provided input does not contain a valid amount'
+      end
+
+      thousands_separator = matches[:ts]
+      decimal_separator = matches[:ds]
+
+      # A single thousands separator without a decimal separator might be considered a decimal
+      # separator in some cases (e.g. '1.001 TND' is likely 1.001 and not 1001). Here we need to
+      # check if the currency allows 3+ subunits.
+      if thousands_separator &&
+          !decimal_separator &&
+          currency.subunit_to_unit > 100 &&
+          amount.count(thousands_separator) == 1
+        _, possible_subunits = amount.split(thousands_separator)
+
+        if possible_subunits.length > 2
+          decimal_separator = thousands_separator
+          thousands_separator = nil
+        end
+      end
+
+      amount.gsub!(thousands_separator, '') if thousands_separator
+      amount.gsub!(decimal_separator, '.') if decimal_separator
+      amount = amount.to_f
+
+      amount = apply_multiplier(amount, multiplier)
+      amount = apply_sign(amount, sign.to_s)
+
+      amount
+    end
+
+    def parse_symbol(symbol)
+      Money::Currency.wrap(CURRENCY_SYMBOLS[symbol])
+    end
+
+    def parse_currency_iso(currency_iso)
+      Money::Currency.wrap(currency_iso)
+    end
+
+    def assume_from_symbol?
+      options.fetch(:assume_from_symbol) { Monetize.assume_from_symbol }
+    end
+
+    def apply_multiplier(num, multiplier)
+      return num unless multiplier
+
+      exponent = MULTIPLIER_SUFFIXES[multiplier.to_s.upcase]
+      num * 10**exponent
+    end
+
+    def apply_sign(num, sign)
+      sign == '-' ? num * -1 : num
+    end
+  end
+end

--- a/lib/monetize/tokenizer.rb
+++ b/lib/monetize/tokenizer.rb
@@ -52,13 +52,12 @@ module Monetize
 
     def match(input, type, regexp)
       tokens = []
-      # TODO: replace with gsub to avoid another loop later?
-      input.scan(regexp) { tokens << Token.new(type, Regexp.last_match) }
-
-      # Replace the matches from the input with § to avoid over-matching
-      tokens.each do |token|
-        offset = token.match.offset(0)
-        input[offset.first..(offset.last - 1)] = REPLACEMENT_SYMBOL * token.match.to_s.length
+      input.gsub!(regexp) do
+        tokens << Token.new(type, Regexp.last_match)
+        # Replace the matches from the input with § to avoid overlapping matches. Stripping
+        # out the matches is dangerous because it can bring things irrelevant things together:
+        # '12USD34' will become '1234' after removing currency, which is NOT expected.
+        REPLACEMENT_SYMBOL * Regexp.last_match.to_s.length
       end
 
       tokens

--- a/lib/monetize/tokenizer.rb
+++ b/lib/monetize/tokenizer.rb
@@ -1,0 +1,78 @@
+require 'monetize/parser'
+
+module Monetize
+  class Tokenizer
+    SYMBOLS = Monetize::Parser::CURRENCY_SYMBOLS.keys.map { |symbol| Regexp.escape(symbol) }.freeze
+    THOUSAND_SEPARATORS = /[\.\ ,]/.freeze
+    DECIMAL_MARKS = /[\.,]/.freeze
+    MULTIPLIERS = Monetize::Parser::MULTIPLIER_SUFFIXES.keys.join('|').freeze
+
+    REPLACEMENT_SYMBOL = '§'.freeze
+    SYMBOL_REGEXP = Regexp.new(SYMBOLS.join('|')).freeze
+    CURRENCY_ISO_REGEXP = /(?<![A-Z])[A-Z]{3}(?![A-Z])/i.freeze
+    SIGN_REGEXP = /[\-\+]/.freeze
+    AMOUNT_REGEXP = %r{
+      (?<amount>                         # amount group
+        \d+                              # starts with at least one digit
+        (?:#{THOUSAND_SEPARATORS}\d{3})* # separated into groups of 3 digits by a thousands separator
+        (?!\d)                           # not followed by a digit
+        (?:#{DECIMAL_MARKS}\d+)?         # might have decimal mark followed by decimal part
+      )
+      (?<multiplier>#{MULTIPLIERS})?     # optional multiplier
+    }ix.freeze
+
+    class Token < Struct.new(:type, :match); end
+
+    def initialize(input, options = {})
+      @original_input = input
+      @options = options
+    end
+
+    def process
+      # matches are removed from the input string to avoid overlapping matches
+      input = original_input.dup
+      result = []
+
+      result += match(input, :currency_iso, CURRENCY_ISO_REGEXP)
+      result += match(input, :symbol, SYMBOL_REGEXP)
+      result += match(input, :sign, SIGN_REGEXP)
+      result += match(input, :amount, AMOUNT_REGEXP)
+
+      # allow only unmatched empty spaces, nothing else
+      unless input.gsub(REPLACEMENT_SYMBOL, '').strip.empty?
+        raise ParseError, 'non-exhaustive match'
+      end
+
+      result.sort_by { |token| token.match.offset(0).first }
+    end
+
+    private
+
+    attr_reader :original_input, :options
+
+    def match(input, type, regexp)
+      tokens = []
+      # TODO: replace with gsub to avoid another loop later?
+      input.scan(regexp) { tokens << Token.new(type, Regexp.last_match) }
+
+      # Replace the matches from the input with § to avoid over-matching
+      tokens.each do |token|
+        offset = token.match.offset(0)
+        input[offset.first..(offset.last - 1)] = REPLACEMENT_SYMBOL * token.match.to_s.length
+      end
+
+      tokens
+    end
+
+    def preview(result)
+      preview_input = original_input.dup
+      result.reverse.each do |token|
+        offset = token.match.offset(0)
+        preview_input.slice!(offset.first, token.match.to_s.length)
+        preview_input.insert(offset.first, "<#{token.type}>")
+      end
+
+      puts preview_input
+    end
+  end
+end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -36,6 +36,17 @@ describe Monetize do
     }
   JSON
 
+  # Dummy parser that always returns an amount and currency specified via options
+  class TestParser < Monetize::Parser
+    def initialize(input, currency, options)
+      @options = options
+    end
+
+    def parse
+      [@options[:amount], @options[:currency]]
+    end
+  end
+
   describe '.parse' do
     it 'parses european-formatted inputs under 10EUR' do
       expect(Monetize.parse('EUR 5,95')).to eq Money.new(595, 'EUR')
@@ -390,6 +401,12 @@ describe Monetize do
         expect(Monetize.parse('£10.00')).to eq Money.new(10_00, 'GBP')
       end
     end
+
+    context 'when specified parser does not exist' do
+      it 'returns nil' do
+        expect(Monetize.parse('100 USD', nil, parser: :foo)).to eq(nil)
+      end
+    end
   end
 
   describe '.parse!' do
@@ -405,6 +422,14 @@ describe Monetize do
 
     it 'raises ArgumentError with invalid format' do
       expect { Monetize.parse!('11..0') }.to raise_error Monetize::ParseError
+    end
+
+    context 'when specified parser does not exist' do
+      it 'raises ArgumentError' do
+        expect do
+          Monetize.parse!('100 USD', nil, parser: :foo)
+        end.to raise_error(Monetize::ArgumentError, 'Parser not registered: foo')
+      end
     end
   end
 
@@ -628,6 +653,41 @@ describe Monetize do
   context 'given the same inputs to .parse and .from_*' do
     it 'gives the same results' do
       expect(4.635.to_money).to eq '4.635'.to_money
+    end
+  end
+
+  describe '.register_parser' do
+    it 'registers a new parser with a provided name' do
+      Monetize.register_parser(:test, TestParser, amount: 42, currency: 'GBP')
+
+      expect(Monetize.parse!('test', nil, parser: :test)).to eq(Money.new(42_00, 'GBP'))
+    end
+
+    it 'registers the same parser with a different name' do
+      Monetize.register_parser(:test_1, TestParser, amount: 1, currency: 'GBP')
+      Monetize.register_parser(:test_2, TestParser, amount: 2, currency: 'USD')
+
+      expect(Monetize.parse!('test', nil, parser: :test_1)).to eq(Money.new(1_00, 'GBP'))
+      expect(Monetize.parse!('test', nil, parser: :test_2)).to eq(Money.new(2_00, 'USD'))
+    end
+
+    it 'overrides existing parser with the same name' do
+      Monetize.register_parser(:test, TestParser, amount: 42, currency: 'GBP')
+      Monetize.register_parser(:test, TestParser, amount: 99, currency: 'USD')
+
+      expect(Monetize.parse!('test', nil, parser: :test)).to eq(Money.new(99_00, 'USD'))
+    end
+  end
+
+  describe '.default_parser=' do
+    before { Monetize.register_parser(:test, TestParser, amount: 1, currency: 'USD') }
+    after { Monetize.default_parser = :optimistic }
+
+    it 'specifies which parser to use by default' do
+      expect(Monetize.parse!('99 GBP')).to eq(Money.new(99_00, 'GBP'))
+
+      Monetize.default_parser = :test
+      expect(Monetize.parse!('99 GBP')).to eq(Money.new(1_00, 'USD'))
     end
   end
 end

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -36,8 +36,6 @@ describe Monetize do
     }
   JSON
 
-  before { Monetize.default_parser = :strict }
-
   # Dummy parser that always returns an amount and currency specified via options
   class TestParser < Monetize::Parser
     def initialize(input, currency, options)

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -36,6 +36,8 @@ describe Monetize do
     }
   JSON
 
+  before { Monetize.default_parser = :strict }
+
   # Dummy parser that always returns an amount and currency specified via options
   class TestParser < Monetize::Parser
     def initialize(input, currency, options)

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -56,7 +56,7 @@ describe Monetize do
           Monetize.assume_from_symbol = false
         end
 
-        Monetize::Parser::CURRENCY_SYMBOLS.each_pair do |symbol, iso_code|
+        Monetize::OptimisticParser::CURRENCY_SYMBOLS.each_pair do |symbol, iso_code|
           context iso_code do
             let(:currency) { Money::Currency.find(iso_code) }
             let(:amount) { 5_95 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,10 @@ require 'money'
 
 RSpec.configure do |config|
   config.order = 'random'
+  if ENV['MODE'] == 'strict'
+    config.before(:each) do
+      Monetize.default_parser = :strict
+    end
+  end
 end
+


### PR DESCRIPTION
⚠️  NOT READY TO BE MERGED YET ⚠️ 

This PR is aimed to be merged on top of #183, hence a few overlapping changes. Once the #183 is merged, I'll rebase this one.

Based on the previous discussion (#164) this PR implements a StrictParser class that aims to only recognise well formatted inputs based on a number of allowed formats that it expects. The idea here is rather simple — when handling money it's better to be conservative with the inputs and discard anything that looks off. This is still rather flexible and with the future improvements (arguments passed via `options`) it can be configured to only allow a couple of formats.

The implementation is based on the tokenization — we first detect any known parts (currency, sign, amount, etc) and then check there's nothing extra left and the order matches one of the expected formats. If anything the implementation should be more straight forward than the OptimisticParser.

This PR also runs the all the existing specs (unmodified) twice — once with each parser to should where they disagree. This is done on purpose to highlight the differences and open them up for discussion.

There are currently 5 different fail cases (about 39 failed specs, but most test the same exact thing):

1. Non-exhaustive matches (`$5.95 ea.`, `L9.99`, `kr.123,45`, `kr9.99`, `20.00 OMG`, `hello 2000 world`) — all these contain text that we couldn't figure out (`kr` is not a listed as a symbol, `OMG` is not a currency we know), therefore I think we shouldn't parse these
2. `nil` input — I think similar to an empty string this should fail, because empty input is not the same as a zero value (which is what OptimisticParser returns)
3. Thousands separator vs decimal mark (`4.635`, `6,534`, `1.550 USD`, `1.009`, `1.001`) — the current approach is based on the two configuration parameters `expect_whole_subunits` and `enforce_currency_delimiters`. The current logic in the StrictParser treats these as thousands unless the currency has a subunit_to_unit ratio > 100. The rationale is to avoid implicit rounding, which comes with it's own set of surprises. This is where I'd love get your input — what's the most intuitive way of treating these?
4. Weird format (`19.12.89`) — this doesn't look like a decimal point input and shouldn't be parsed as monetary value
5. Trailing dot floats (`£.45B`) — I'm somehow conflicted about this, however this is not ambiguous and probably should be allowed. WDYT?