### PR TITLE
Improve currency symbol detection

### DIFF
--- a/lib/monetize.rb
+++ b/lib/monetize.rb
@@ -68,5 +68,17 @@ module Monetize
       fail ArgumentError, "'value' should be a type of Numeric" unless value.is_a?(Numeric)
       Money.from_amount(value, currency)
     end
+
+    def register_currency_symbol(symbol, iso_code)
+      Monetize::Parser.register_currency_symbol(symbol, iso_code)
+    end
+
+    def unregister_currency_symbol(symbol)
+      Monetize::Parser.unregister_currency_symbol(symbol)
+    end
+
+    def reset_currency_symbols!
+      Monetize::Parser.reset_currency_symbols!
+    end
   end
 end

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -119,11 +119,7 @@ module Monetize
     end
 
     def compute_currency_from_iso_code
-      computed_currency = input[/[A-Z]{2,3}/]
-
-      return unless Money::Currency.find(computed_currency)
-
-      computed_currency
+      Money::Currency.find(input[/[A-Z]{2,3}/])
     end
 
     def compute_currency_from_symbol

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -79,14 +79,27 @@ module Monetize
     end
 
     def parse_currency
-      computed_currency = nil
-      computed_currency = input[/[A-Z]{2,3}/]
-      computed_currency = nil unless Money::Currency.find(computed_currency)
-      computed_currency ||= compute_currency if assume_from_symbol?
+      computed_currency = compute_currency_from_iso_code
+      computed_currency ||= compute_currency_from_symbol if assume_from_symbol?
+      computed_currency ||= fallback_currency || Money.default_currency
 
-      found = computed_currency || fallback_currency || Money.default_currency
-      raise Money::Currency::UnknownCurrency unless found
-      found
+      raise Money::Currency::UnknownCurrency unless computed_currency
+
+      computed_currency
+    end
+
+    def compute_currency_from_iso_code
+      computed_currency = input[/[A-Z]{2,3}/]
+
+      return unless Money::Currency.find(computed_currency)
+
+      computed_currency
+    end
+
+    def compute_currency_from_symbol
+      match = input.match(CURRENCY_SYMBOL_REGEX)
+
+      CURRENCY_SYMBOLS[match.to_s] if match
     end
 
     def assume_from_symbol?
@@ -103,11 +116,6 @@ module Monetize
 
     def apply_sign(negative, amount)
       negative ? amount * -1 : amount
-    end
-
-    def compute_currency
-      match = input.match(CURRENCY_SYMBOL_REGEX)
-      CURRENCY_SYMBOLS[match.to_s] if match
     end
 
     def remove_separator(num, separator)

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -1,6 +1,15 @@
 module Monetize
   class Parser
-    CURRENCY_SYMBOLS = {
+    MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
+    MULTIPLIER_SUFFIXES.default = 0
+    MULTIPLIER_REGEXP = /^(.*?\d)(#{MULTIPLIER_SUFFIXES.keys.join('|')})\b([^\d]*)$/i
+
+    DEFAULT_DECIMAL_MARK = '.'.freeze
+    DEFAULT_MINOR = "00".freeze
+
+    private_constant :DEFAULT_MINOR
+
+    @@original_currency_symbols = {
       '$'  => 'USD',
       '€'  => 'EUR',
       '£'  => 'GBP',
@@ -26,17 +35,38 @@ module Monetize
       'S$' => 'SGD',
       'HK$'=> 'HKD',
       'NT$'=> 'TWD',
-      '₱'  => 'PHP',
-    }
+      '₱'  => 'PHP'
+    }.freeze
 
-    CURRENCY_SYMBOL_REGEX = /(?<![A-Z])(#{CURRENCY_SYMBOLS.keys.map { |key| Regexp.escape(key) }.join('|')})(?![A-Z])/i
-    MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
-    MULTIPLIER_SUFFIXES.default = 0
-    MULTIPLIER_REGEXP = Regexp.new(format('^(.*?\d)(%s)\b([^\d]*)$', MULTIPLIER_SUFFIXES.keys.join('|')), 'i')
+    class << self
+      def currency_symbols
+        @@currency_symbols ||= @@original_currency_symbols.dup
+      end
 
-    DEFAULT_DECIMAL_MARK = '.'.freeze
-    DEFAULT_MINOR = "00".freeze
-    private_constant :DEFAULT_MINOR
+      def register_currency_symbol(symbol, iso_code)
+        @@currency_symbols[symbol] = iso_code
+
+        reset_currency_symbol_regex
+      end
+
+      def unregister_currency_symbol(symbol)
+        @@currency_symbols.delete(symbol)
+        reset_currency_symbol_regex
+      end
+
+      def reset_currency_symbols!
+        @@currency_symbols = @@original_currency_symbols.dup
+        reset_currency_symbol_regex
+      end
+
+      def currency_symbol_regex
+        @@currency_symbol_regex ||= /(?<![A-Z])(#{currency_symbols.keys.map { |key| Regexp.escape(key) }.join('|')})(?![A-Z])/i
+      end
+
+      def reset_currency_symbol_regex
+        @@currency_symbol_regex = nil
+      end
+    end
 
     def initialize(input, fallback_currency = Money.default_currency, options = {})
       @input = input.to_s.strip
@@ -97,9 +127,9 @@ module Monetize
     end
 
     def compute_currency_from_symbol
-      match = input.match(CURRENCY_SYMBOL_REGEX)
+      match = input.match(self.class.currency_symbol_regex)
 
-      CURRENCY_SYMBOLS[match.to_s] if match
+      self.class.currency_symbols[match.to_s] if match
     end
 
     def assume_from_symbol?

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -44,13 +44,13 @@ module Monetize
       end
 
       def register_currency_symbol(symbol, iso_code)
-        @@currency_symbols[symbol] = iso_code
+        currency_symbols[symbol] = iso_code
 
         reset_currency_symbol_regex
       end
 
       def unregister_currency_symbol(symbol)
-        @@currency_symbols.delete(symbol)
+        currency_symbols.delete(symbol)
         reset_currency_symbol_regex
       end
 

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -148,6 +148,16 @@ describe Monetize do
             expect(Monetize.parse("€19.90")).to eq Money.new(1990, "USD")
           end
 
+          it "registers currency symbol before currency_symbols is accessed" do
+            Monetize::Parser.class_variable_set(:@@currency_symbols, nil)
+
+            expect {
+              Monetize.register_currency_symbol("S/", "PEN")
+            }.not_to raise_error
+
+            expect(Monetize.parse("S/19.90")).to eq Money.new(1990, "PEN")
+          end
+
           it "unregisters custom currency symbol" do
             Monetize.register_currency_symbol("S/", "PEN")
 

--- a/spec/monetize_spec.rb
+++ b/spec/monetize_spec.rb
@@ -54,7 +54,7 @@ describe Monetize do
           Monetize.assume_from_symbol = false
         end
 
-        Monetize::Parser::CURRENCY_SYMBOLS.each_pair do |symbol, iso_code|
+        Monetize::Parser.currency_symbols.each_pair do |symbol, iso_code|
           context iso_code do
             let(:currency) { Money::Currency.find(iso_code) }
             let(:amount) { 5_95 }
@@ -132,6 +132,57 @@ describe Monetize do
             expect(Monetize.parse('kr9.99')).to eq Money.new(999, 'USD')
           end
         end
+
+        context "registered custom symbols and unregistering" do
+          after { Monetize.reset_currency_symbols! }
+
+          it "parses registered custom currency symbol" do
+            Monetize.register_currency_symbol("S/", "PEN")
+
+            expect(Monetize.parse("S/19.90")).to eq Money.new(1990, "PEN")
+          end
+
+          it "overrides existing currency symbol when registering" do
+            Monetize.register_currency_symbol("€", "USD")
+
+            expect(Monetize.parse("€19.90")).to eq Money.new(1990, "USD")
+          end
+
+          it "unregisters custom currency symbol" do
+            Monetize.register_currency_symbol("S/", "PEN")
+
+            expect(Monetize.parse("S/19.90")).to eq Money.new(1990, "PEN")
+
+            Monetize.unregister_currency_symbol("S/")
+
+            expect(Monetize.parse("S/19.90")).to eq Money.new(1990, "USD")
+          end
+
+          it "unregisters existing currency symbol" do
+            Monetize.unregister_currency_symbol("€")
+
+            expect(Monetize.parse("€19.90")).to eq Money.new(1990, "USD")
+          end
+
+          it "unregisters non-registered currency symbol without errors" do
+            expect {
+              Monetize.unregister_currency_symbol("XYZ")
+            }.not_to raise_error
+          end
+
+          it "resets currency symbols to original set" do
+            Monetize.register_currency_symbol("S/", "PEN")
+            Monetize.unregister_currency_symbol("€")
+
+            expect(Monetize.parse("S/19.90")).to eq Money.new(1990, "PEN")
+            expect(Monetize.parse("€19.90")).to eq Money.new(1990, "USD")
+
+            Monetize.reset_currency_symbols!
+
+            expect(Monetize.parse("€19.90")).to eq Money.new(1990, "EUR")
+            expect(Monetize.parse("S/19.90")).to eq Money.new(1990, "USD")
+          end
+        end
       end
 
       context 'opted out' do
@@ -172,7 +223,7 @@ describe Monetize do
         end
 
         it 'parses currency not in CURRENCY_SYMBOLS given as ISO code' do
-          expect(Monetize::Parser::CURRENCY_SYMBOLS).to_not have_value('DKK')
+          expect(Monetize::Parser.currency_symbols).to_not have_value('DKK')
           expect('20.00 DKK'.to_money).to eq Money.new(20_00, 'DKK')
         end
 


### PR DESCRIPTION
**Update:** I recently noticed that parsing by ISO code (e.g., PEN10) has been fixed in the main branch. Therefore, this PR now focuses strictly on symbol detection (e.g., S/10), which still defaults to USD.


Expected behavior:
```ruby
Monetize.parse('S/10') # <Money fractional:1000 currency:PEN>
```

Current behavior:
```ruby
Monetize.parse('S/10') # <Money fractional:1000 currency:USD>
```

## Proposed Solution
I implemented a manual registration strategy via `register_currency_symbol`.

**Why not auto-load all symbols?**
I discarded the initial proposal (auto-loading from `Money::Currency.table`) because:

1. **Conflicts:** Many symbols clash with decimal marks or suffixes (e.g., "K").
2. **Inefficiency:** Trying to list and "ignore" every problematic symbol proved to be laborious and hard to maintain.
3. **Control:** Since ISO codes are already loaded, it is more efficient to explicitly register only the symbols needed rather than loading the entire table with potential edge cases.

**Usage:**
```ruby
Monetize.register_currency_symbol("S/", "PEN")

Monetize.parse("S/19.90") # <Money fractional:1990 currency:PEN>
```