### PR TITLE
Test against Ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .ruby-version
+.tool-versions


### PR DESCRIPTION
Ruby 3.4 is missing in the spec matrix. Recently, there was a behavior change in BigDecimal that won't be noticed until the 3.4 version.
The build will fail until https://github.com/RubyMoney/monetize/pull/189 is merged.