### PR TITLE
Cache currency symbol regex to improve parse performance

### DIFF
--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -188,8 +188,13 @@ module Monetize
       [major, minor || '00']
     end
 
+    CURRENCY_SYMBOL_REGEX = begin
+      regex_safe_symbols = CURRENCY_SYMBOLS.keys.map { |key| Regexp.escape(key) }.join('|')
+      Regexp.new("(?<![A-Z])(#{regex_safe_symbols})(?![A-Z])", Regexp::IGNORECASE)
+    end.freeze
+    
     def currency_symbol_regex
-      /(?<![A-Z])(#{regex_safe_symbols})(?![A-Z])/i
+      CURRENCY_SYMBOL_REGEX
     end
   end
 end

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -189,7 +189,6 @@ module Monetize
     end
 
     CURRENCY_SYMBOL_REGEX = begin
-      regex_safe_symbols = CURRENCY_SYMBOLS.keys.map { |key| Regexp.escape(key) }.join('|')
       Regexp.new("(?<![A-Z])(#{regex_safe_symbols})(?![A-Z])", Regexp::IGNORECASE)
     end.freeze
     

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -30,7 +30,8 @@ module Monetize
       'NT$'=> 'TWD',
       '₱'  => 'PHP',
     }
-
+    
+    CURRENCY_SYMBOL_REGEX = /(?<![A-Z])(#{CURRENCY_SYMBOLS.keys.map { |key| Regexp.escape(key) }.join('|')})(?![A-Z])/i
     MULTIPLIER_SUFFIXES = { 'K' => 3, 'M' => 6, 'B' => 9, 'T' => 12 }
     MULTIPLIER_SUFFIXES.default = 0
     MULTIPLIER_REGEXP = Regexp.new(format('^(.*?\d)(%s)\b([^\d]*)$', MULTIPLIER_SUFFIXES.keys.join('|')), 'i')
@@ -100,7 +101,7 @@ module Monetize
     end
 
     def compute_currency
-      match = input.match(currency_symbol_regex)
+      match = input.match(CURRENCY_SYMBOL_REGEX)
       CURRENCY_SYMBOLS[match.to_s] if match
     end
 
@@ -179,19 +180,9 @@ module Monetize
       result
     end
 
-    def regex_safe_symbols
-      CURRENCY_SYMBOLS.keys.map { |key| Regexp.escape(key) }.join('|')
-    end
-
     def split_major_minor(num, delimiter)
       major, minor = num.split(delimiter)
       [major, minor || '00']
-    end
-
-    CURRENCY_SYMBOL_REGEX = /(?<![A-Z])(#{regex_safe_symbols})(?![A-Z])/i
-    
-    def currency_symbol_regex
-      CURRENCY_SYMBOL_REGEX
     end
   end
 end

--- a/lib/monetize/parser.rb
+++ b/lib/monetize/parser.rb
@@ -188,9 +188,7 @@ module Monetize
       [major, minor || '00']
     end
 
-    CURRENCY_SYMBOL_REGEX = begin
-      Regexp.new("(?<![A-Z])(#{regex_safe_symbols})(?![A-Z])", Regexp::IGNORECASE)
-    end.freeze
+    CURRENCY_SYMBOL_REGEX = /(?<![A-Z])(#{regex_safe_symbols})(?![A-Z])/i
     
     def currency_symbol_regex
       CURRENCY_SYMBOL_REGEX


### PR DESCRIPTION
Cached the currency symbol regex in Parser to avoid recompiling it on every parse call, improving performance during repeated monetary parsing operations.

```
Benchmarking currency_symbol_regex creation...
                                user     system      total        real
Dynamic regex generation:   0.551297   0.001920   0.553217 (  0.553221)
Cached regex reuse:         0.003189   0.000083   0.003272 (  0.003271)
```